### PR TITLE
chore(plans): clear storage-foundation awaits after gitsheets v1.0.3

### DIFF
--- a/plans/storage-foundation.md
+++ b/plans/storage-foundation.md
@@ -13,8 +13,6 @@ upstream-specs:
   - gitsheets:specs/behaviors/transactions.md
   - gitsheets:specs/behaviors/validation.md
   - gitsheets:specs/behaviors/normalization.md
-awaits:
-  - "JarvusInnovations/gitsheets@v1.0 — consumed via Repository / Sheet / openStore TypeScript API (https://github.com/JarvusInnovations/gitsheets/milestone/1)"
 issues: []
 ---
 


### PR DESCRIPTION
## Summary

- Removes the `awaits:` entry from `plans/storage-foundation.md` now that gitsheets v1.0 has shipped to NPM (`gitsheets@1.0.3` is `latest`).
- Resolution per the convention is just deleting the entry — no other ceremony.
- The Scope prose ("Assumes gitsheets v1.0 has shipped") stays; it carries more context than the YAML did.

After this, storage-foundation's only blocker is `depends: [test-harness]`. Once test-harness lands, storage-foundation is the next plan ready to execute.

## Test plan

- [x] `git grep awaits` returns nothing in `plans/` after this change
- [x] No other plan references `gitsheets@v1.0` as a hard pin (verified: only this `awaits:` entry referenced the tag)
- [x] gitsheets@1.0.3 is `latest` on NPM (`npm view gitsheets version` → `1.0.3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)