### PR TITLE
fix(lint): ignore .agents/ (skill sources upstream-managed)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,9 @@ export default tseslint.config(
       '**/.vite/**',
       '**/coverage/**',
       '.claude/worktrees/**',
+      // Skill source is upstream-managed (hash-pinned in skills-lock.json);
+      // its scripts ship as CommonJS and aren't ours to relint.
+      '.agents/**',
     ],
   },
   js.configs.recommended,


### PR DESCRIPTION
PR #71 merged with a red CI — the failure was lint on the new `.agents/skills/specops/scripts/lib/plans.js` (CommonJS, flagged by the project's flat-config eslint).

Skill sources are upstream-managed via `skills-lock.json`'s content hash — modifying them would break the sync. The right fix is to ignore the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)