### PR TITLE
ops(runbook): script for fetching from the pod's data clone

### DIFF
--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -148,6 +148,31 @@ for the authoritative contract. Operationally:
   with the outcome + commits; failures log error. Search the pod logs
   for `hot-reload` to audit the most recent firings.
 
+## Fetch from the pod's data clone
+
+The pod's working tree lives on a PVC at `/app/data` inside the container and may briefly hold commits the push daemon hasn't shipped to GitHub yet (or that got escape-hatched onto a `conflicts/*` branch — those *are* always pushed, see [`apps/api/src/store/reconcile.ts`](../../apps/api/src/store/reconcile.ts)). When you want to inspect the pod's view of the data repo without exposing any network ports, add it as a git remote via the `ext::` transport.
+
+```bash
+cd /path/to/codeforphilly-data
+
+git config protocol.ext.allow always
+git remote add pod 'ext::sh /path/to/codeforphilly-ng/scripts/git-pod-uploadpack.sh'
+
+git fetch pod
+git log --oneline pod/published..pod/published   # whatever you're chasing
+```
+
+The helper script resolves the current pod by label selector, so it survives restarts. Override via env if your setup differs:
+
+| Var | Default |
+|---|---|
+| `CFP_POD_KUBECONFIG` | `~/.kube/cfp-sandbox-cluster-kubeconfig.yaml` |
+| `CFP_POD_NAMESPACE` | `codeforphilly-rewrite-sandbox` |
+| `CFP_POD_SELECTOR` | `app.kubernetes.io/name=codeforphilly` |
+| `CFP_POD_DATA_PATH` | `/app/data` |
+
+**Read-only by design** — `git upload-pack` only serves fetch; pushing back to the pod would bypass gitsheets + in-memory state and fight the push daemon. Pull what you need to your local clone, reason about it there, then push to `origin` if appropriate.
+
 ## Helpful commands
 
 ```bash

--- a/scripts/git-pod-uploadpack.sh
+++ b/scripts/git-pod-uploadpack.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Spawn `git upload-pack` inside the running sandbox pod so you can fetch from
+# the pod's PVC-backed data clone as a git remote. Designed to be plumbed into
+# git's `ext::` transport — see docs/operations/runbook.md → "Fetch from the
+# pod's data clone".
+#
+# Env (all optional, sensible defaults baked in):
+#   CFP_POD_KUBECONFIG  — path to kubeconfig (default ~/.kube/cfp-sandbox-cluster-kubeconfig.yaml)
+#   CFP_POD_NAMESPACE   — k8s namespace                (default codeforphilly-rewrite-sandbox)
+#   CFP_POD_SELECTOR    — label selector for the pod   (default app.kubernetes.io/name=codeforphilly)
+#   CFP_POD_DATA_PATH   — repo path inside the pod     (default /app/data)
+set -euo pipefail
+
+KUBECONFIG_PATH="${CFP_POD_KUBECONFIG:-$HOME/.kube/cfp-sandbox-cluster-kubeconfig.yaml}"
+NAMESPACE="${CFP_POD_NAMESPACE:-codeforphilly-rewrite-sandbox}"
+SELECTOR="${CFP_POD_SELECTOR:-app.kubernetes.io/name=codeforphilly}"
+DATA_PATH="${CFP_POD_DATA_PATH:-/app/data}"
+
+POD=$(kubectl --kubeconfig="$KUBECONFIG_PATH" -n "$NAMESPACE" \
+  get pod -l "$SELECTOR" --field-selector=status.phase=Running \
+  -o jsonpath='{.items[0].metadata.name}')
+
+if [[ -z "$POD" ]]; then
+  echo "git-pod-uploadpack: no Running pod matched $SELECTOR in $NAMESPACE" >&2
+  exit 1
+fi
+
+exec kubectl --kubeconfig="$KUBECONFIG_PATH" -n "$NAMESPACE" \
+  exec -i "$POD" -- git upload-pack "$DATA_PATH"


### PR DESCRIPTION
## Summary

A tiny helper + runbook section for adding the sandbox pod's PVC-backed data clone as a git remote in your local data repo. Useful when chasing divergence between what the pod has on disk and what's pushed to GitHub — e.g. push-daemon backlog, escape-hatched `conflicts/*` branches, or just diagnosing pod state when something's wedged.

- `scripts/git-pod-uploadpack.sh` — resolves the pod by label selector each call (survives restarts), exec's `git upload-pack /app/data` inside it. All knobs (kubeconfig, namespace, selector, data path) overridable via env with sandbox-friendly defaults.
- `docs/operations/runbook.md` — new section between "Hot-reload webhook" and "Helpful commands" with the one-time setup (`git config protocol.ext.allow always`, `git remote add pod 'ext::sh …'`) and the env table.

Read-only by design — `git upload-pack` only serves fetch; pushing into the pod would bypass gitsheets and fight the push daemon.

## Test plan

- [x] `git fetch pod` against the live sandbox returns `pod/published` and the pod-resident `conflicts/2026-05-19T22-57-23Z` branch
- [ ] After pod restart, `git fetch pod` still works (label selector resolution survives)
- [ ] Env overrides (`CFP_POD_NAMESPACE=…`) let you point at a different pod / cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)