### PR TITLE
feat(api): slug-history 301 redirect handler (closes #80)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -38,6 +38,7 @@ import reconcilePlugin from './plugins/reconcile.js';
 import pushDaemonPlugin from './plugins/push-daemon.js';
 import servicesPlugin from './plugins/services.js';
 import markdownPlugin from './plugins/markdown.js';
+import slugRedirectPlugin from './plugins/slug-redirect.js';
 import rateLimitPlugin from './plugins/rate-limit.js';
 import idempotencyPlugin from './plugins/idempotency.js';
 import sessionMiddlewarePlugin from './auth/middleware.js';
@@ -131,6 +132,7 @@ export async function buildApp(opts: BuildAppOptions = {}): Promise<FastifyInsta
   // ----- 6c. Services (loads in-memory state + FTS, boots after store) -----
   await fastify.register(servicesPlugin);
   await fastify.register(markdownPlugin);
+  await fastify.register(slugRedirectPlugin);
 
   // ----- 7. Rate limiting -----
   await fastify.register(rateLimitPlugin);

--- a/apps/api/src/plugins/slug-redirect.ts
+++ b/apps/api/src/plugins/slug-redirect.ts
@@ -1,0 +1,183 @@
+/**
+ * Slug-history redirect plugin.
+ *
+ * Serves 301s for non-expired SlugHistory entries per
+ * specs/behaviors/slug-handles.md → "Mutability and redirects". Pattern-
+ * matches the slug-bearing SPA paths on every non-/api/* GET; for live-
+ * missing slugs that have a SlugHistory entry, redirects to the canonical
+ * URL with the suffix preserved.
+ *
+ * Spec edge cases handled:
+ *   - **Live wins** — if `oldSlug` is currently a live entity of the same
+ *     type (someone took the freed slug), no redirect.
+ *   - **Multi-hop chains** — A → B → C resolves to C in one response via
+ *     in-process chain follow, capped at MAX_HOPS to short-circuit
+ *     pathological inputs.
+ *   - **Expired entries** — past-`expiresAt` records are dropped at index
+ *     time (`indexSlugHistory`) so the lookup naturally misses.
+ *   - **Tag namespace** — `/tags/:namespace/:slug` rewrites the slug while
+ *     preserving the namespace; the SlugHistory key is `tag:<slug>`
+ *     regardless of namespace (matches the schema's lookup shape).
+ *
+ * Plugin order: registered after `services` (decorates `inMemoryState`)
+ * and before `static-web` (which owns the SPA fallthrough notFoundHandler).
+ */
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import fp from 'fastify-plugin';
+
+import type { SlugHistory } from '@cfp/shared/schemas';
+
+import { slugHistoryKey, type InMemoryState } from '../store/memory/state.js';
+
+const MAX_HOPS = 8;
+
+type EntityType = SlugHistory['entityType'];
+
+/**
+ * Pattern descriptor for a slug-bearing path. Each pattern declares the
+ * regex that extracts the slug component(s) and a function that rebuilds
+ * the URL once we've resolved any renames.
+ */
+interface RoutePattern {
+  /** Entity type that the slug-history lookup keys on. */
+  readonly entityType: EntityType;
+  /**
+   * Regex against `path` (origin-relative; query stripped). Must contain a
+   * single capture group for the slug component, except `tag` which captures
+   * (namespace, slug).
+   */
+  readonly match: RegExp;
+  /** Live-entity check — returns the canonical slug if this slug is live, else null. */
+  readonly liveIndex: (state: InMemoryState, slug: string) => boolean;
+  /** Rebuild the path with the resolved slug substituted in place of the original. */
+  readonly rebuild: (match: RegExpExecArray, resolvedSlug: string) => string;
+}
+
+const patterns: readonly RoutePattern[] = [
+  // /projects/<slug>/buzz/<buzzSlug>... — both legs are renamable. The deeper
+  // match runs first so we attempt to resolve both buzz and project; either
+  // can independently redirect.
+  // (Currently no slug-history writer for buzz, but the spec includes 'buzz'
+  // in SlugHistory.entityType so the plumbing supports it.)
+  {
+    entityType: 'buzz',
+    match: /^\/projects\/([^/]+)\/buzz\/([^/]+)(\/.*)?$/,
+    liveIndex: (state, slug) => {
+      // Buzz slugs are keyed by `${projectId}:${buzzSlug}` in the live index;
+      // since we don't have the projectId at this point cheaply, treat the
+      // slug as missing-from-live whenever a slug-history record exists.
+      // This is the spec-permitted behavior: if a freed buzz slug was taken
+      // by a different project, the slug-history record points away anyway.
+      void state;
+      void slug;
+      return false;
+    },
+    rebuild: (m, resolved) => `/projects/${m[1]}/buzz/${resolved}${m[3] ?? ''}`,
+  },
+  {
+    entityType: 'project',
+    match: /^\/projects\/([^/]+)(\/.*)?$/,
+    liveIndex: (state, slug) => state.projectIdBySlug.has(slug),
+    rebuild: (m, resolved) => `/projects/${resolved}${m[2] ?? ''}`,
+  },
+  {
+    entityType: 'person',
+    match: /^\/members\/([^/]+)(\/.*)?$/,
+    liveIndex: (state, slug) => state.personIdBySlug.has(slug),
+    rebuild: (m, resolved) => `/members/${resolved}${m[2] ?? ''}`,
+  },
+  {
+    entityType: 'tag',
+    // Capture namespace + slug; namespace stays unchanged in the rebuild.
+    match: /^\/tags\/([^/]+)\/([^/]+)(\/.*)?$/,
+    liveIndex: (state, slug) => {
+      // Tags are uniquely keyed by `(namespace, slug)`; we look up `tag:<slug>`
+      // in slug-history regardless of namespace. Live-check checks any
+      // namespace match — if the slug is in use by ANY namespace it counts
+      // as "live wins". Tags rarely collide across namespaces so this is
+      // conservative.
+      for (const handle of state.tagIdByHandle.keys()) {
+        if (handle.endsWith(`.${slug}`)) return true;
+      }
+      return false;
+    },
+    rebuild: (m, resolved) => `/tags/${m[1]}/${resolved}${m[3] ?? ''}`,
+  },
+];
+
+/**
+ * Follow the slug-history chain in-process up to MAX_HOPS, stopping at the
+ * first slug that is live (or absent from slug-history). Returns null when
+ * no rewriting is needed (slug already live, or no slug-history entry, or
+ * the chain bottoms out at the same slug).
+ */
+function resolveSlug(
+  state: InMemoryState,
+  pattern: RoutePattern,
+  startSlug: string,
+): string | null {
+  // Live first — never redirect away from a slug that's currently a real entity.
+  if (pattern.liveIndex(state, startSlug)) return null;
+
+  let current = startSlug;
+  for (let hop = 0; hop < MAX_HOPS; hop++) {
+    const entry = state.slugHistory.get(slugHistoryKey(pattern.entityType, current));
+    if (!entry) {
+      // No more slug-history to follow. Return null if we never moved.
+      return current === startSlug ? null : current;
+    }
+    if (entry.newSlug === current) {
+      // Defensive: pathological self-loop.
+      return current === startSlug ? null : current;
+    }
+    current = entry.newSlug;
+    // If the chain has reached a live slug, we're done — return it.
+    if (pattern.liveIndex(state, current)) return current;
+  }
+  // Chain too long — log + bail. The first hop's destination is what we return.
+  return current === startSlug ? null : current;
+}
+
+async function slugRedirectPlugin(fastify: FastifyInstance): Promise<void> {
+  fastify.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {
+    if (request.method !== 'GET' && request.method !== 'HEAD') return;
+    // Strip query before pattern-matching; preserve it for the rebuilt URL.
+    const url = request.url;
+    if (url.startsWith('/api/')) return;
+    const queryIdx = url.indexOf('?');
+    const path = queryIdx === -1 ? url : url.slice(0, queryIdx);
+    const query = queryIdx === -1 ? '' : url.slice(queryIdx);
+
+    const state = fastify.inMemoryState;
+
+    for (const pattern of patterns) {
+      const m = pattern.match.exec(path);
+      if (!m) continue;
+      // For the tag pattern the captured slug is in group 2; everywhere else
+      // it's group 1. (Buzz pattern's renamable leg is also group 2.)
+      const slugGroup = pattern.entityType === 'tag' || pattern.entityType === 'buzz' ? 2 : 1;
+      const slug = m[slugGroup];
+      if (!slug) continue;
+
+      const resolved = resolveSlug(state, pattern, slug);
+      if (!resolved) continue;
+
+      const newPath = pattern.rebuild(m, resolved);
+      const target = newPath + query;
+      // 5-minute cache: the redirect itself may expire when the 90-day
+      // window does; a short cache balances perf with not lying to clients
+      // about a permanent-looking redirect.
+      await reply
+        .code(301)
+        .header('Location', target)
+        .header('Cache-Control', 'public, max-age=300')
+        .send();
+      return;
+    }
+  });
+}
+
+export default fp(slugRedirectPlugin, {
+  name: 'slug-redirect',
+  dependencies: ['services'],
+});

--- a/apps/api/src/services/account-claim.ts
+++ b/apps/api/src/services/account-claim.ts
@@ -684,6 +684,9 @@ export class AccountClaimService {
     await tx.public['slug-history'].upsert(slugHistory);
 
     // Hard-delete the requester Person -----------------------------------
+    // (the slugHistory record is replayed into the in-memory state via
+    // MergeApply below — same lockstep guarantee the other state-apply
+    // ops get.)
 
     await tx.public.people.delete(requester);
 
@@ -711,6 +714,7 @@ export class AccountClaimService {
       updatedPerson: updatedClaimed,
       deletedRequesterPersonId: requester.id,
       deletedRequesterSlug: requester.slug,
+      slugHistory,
       reMemberships,
       removedMemberships,
       reUpdates,
@@ -730,6 +734,7 @@ interface MergeApplyInput {
   readonly updatedPerson: Person;
   readonly deletedRequesterPersonId: string;
   readonly deletedRequesterSlug: string;
+  readonly slugHistory: SlugHistory;
   readonly reMemberships: ProjectMembership[];
   readonly removedMemberships: ProjectMembership[];
   readonly reUpdates: ProjectUpdate[];
@@ -760,6 +765,7 @@ export class MergeApply {
   replay(stateApply: StateApply): void {
     const i = this.#input;
     stateApply.upsertPerson(i.updatedPerson);
+    stateApply.upsertSlugHistory(i.slugHistory);
     for (const m of i.reMemberships) stateApply.upsertMembership(m);
     for (const m of i.removedMemberships) stateApply.removeMembership(m);
     for (const u of i.reUpdates) stateApply.upsertProjectUpdate(u);

--- a/apps/api/src/services/person.write.ts
+++ b/apps/api/src/services/person.write.ts
@@ -125,6 +125,7 @@ export class PersonWriteService {
       };
       await tx.public['slug-history'].upsert(history);
       stateApply.renamePersonSlug(existing.id, existing.slug, newSlug);
+      stateApply.upsertSlugHistory(history);
     }
 
     await tx.public.people.upsert(updated);

--- a/apps/api/src/services/project.write.ts
+++ b/apps/api/src/services/project.write.ts
@@ -302,6 +302,7 @@ export class ProjectWriteService {
       };
       await tx.public['slug-history'].upsert(history);
       stateApply.renameProjectSlug(existing.id, slugRename.oldSlug, slugRename.newSlug);
+      stateApply.upsertSlugHistory(history);
     }
 
     await tx.public.projects.upsert(updated);

--- a/apps/api/src/store/memory/loader.ts
+++ b/apps/api/src/store/memory/loader.ts
@@ -14,6 +14,7 @@ import {
   indexProject,
   indexProjectBuzz,
   indexProjectUpdate,
+  indexSlugHistory,
   indexTag,
   indexTagAssignment,
   type InMemoryState,
@@ -32,6 +33,7 @@ export async function loadInMemoryState(publicStore: PublicStore): Promise<InMem
     buzzes,
     roles,
     interests,
+    slugHistoryRecords,
   ] = await Promise.all([
     publicStore.projects.queryAll(),
     publicStore.people.queryAll(),
@@ -42,6 +44,7 @@ export async function loadInMemoryState(publicStore: PublicStore): Promise<InMem
     publicStore['project-buzz'].queryAll(),
     publicStore['help-wanted-roles'].queryAll(),
     publicStore['help-wanted-interest'].queryAll(),
+    publicStore['slug-history'].queryAll(),
   ]);
 
   for (const p of projects) indexProject(state, p);
@@ -53,6 +56,11 @@ export async function loadInMemoryState(publicStore: PublicStore): Promise<InMem
   for (const b of buzzes) indexProjectBuzz(state, b);
   for (const r of roles) indexHelpWantedRole(state, r);
   for (const i of interests) indexHelpWantedInterest(state, i);
+  // Slug-history is filtered for expiry inside indexSlugHistory — records
+  // past their 90-day window are skipped (the sheet retains them until a
+  // separate sweeper purges; this is the read-path defense).
+  const bootNow = new Date();
+  for (const r of slugHistoryRecords) indexSlugHistory(state, r, bootNow);
 
   return state;
 }

--- a/apps/api/src/store/memory/state.ts
+++ b/apps/api/src/store/memory/state.ts
@@ -15,6 +15,7 @@ import type {
   ProjectBuzz,
   ProjectMembership,
   ProjectUpdate,
+  SlugHistory,
   Tag,
   TagAssignment,
 } from '@cfp/shared/schemas';
@@ -78,6 +79,20 @@ export interface InMemoryState {
   interestByRoleAndPerson: Map<string, string>;
   /** roleId → Set<interestId> */
   interestByRole: Map<string, Set<string>>;
+
+  /**
+   * Slug-history index, keyed by `${entityType}:${oldSlug}` → newSlug + expiry.
+   * Populated at boot from non-expired SlugHistory records; updated in
+   * lockstep with rename writes via StateApply.upsertSlugHistory. The
+   * `slug-redirect` plugin reads this on every non-/api/* GET request to
+   * decide whether to serve a 301 per specs/behaviors/slug-handles.md.
+   */
+  slugHistory: Map<string, { newSlug: string; expiresAt: string }>;
+}
+
+/** Compose the slug-history map key. Kept here so call sites stay consistent. */
+export function slugHistoryKey(entityType: SlugHistory['entityType'], oldSlug: string): string {
+  return `${entityType}:${oldSlug}`;
 }
 
 export function createEmptyState(): InMemoryState {
@@ -108,7 +123,22 @@ export function createEmptyState(): InMemoryState {
     tagAssignmentsByTag: new Map(),
     interestByRoleAndPerson: new Map(),
     interestByRole: new Map(),
+    slugHistory: new Map(),
   };
+}
+
+/**
+ * Index a SlugHistory record into the in-memory map. Expired records (where
+ * `expiresAt < now`) are dropped — the periodic sweeper that purges them
+ * from the gitsheets sheet is a separate concern; this is the read-path
+ * defense.
+ */
+export function indexSlugHistory(state: InMemoryState, record: SlugHistory, now: Date = new Date()): void {
+  if (new Date(record.expiresAt) <= now) return;
+  state.slugHistory.set(slugHistoryKey(record.entityType, record.oldSlug), {
+    newSlug: record.newSlug,
+    expiresAt: record.expiresAt,
+  });
 }
 
 /** Add or replace one project and update its secondary indices. */

--- a/apps/api/src/store/state-apply.ts
+++ b/apps/api/src/store/state-apply.ts
@@ -15,6 +15,7 @@ import type {
   ProjectBuzz,
   ProjectMembership,
   ProjectUpdate,
+  SlugHistory,
   Tag,
   TagAssignment,
 } from '@cfp/shared/schemas';
@@ -28,6 +29,7 @@ import {
   indexProject,
   indexProjectBuzz,
   indexProjectUpdate,
+  indexSlugHistory,
   indexTag,
   indexTagAssignment,
   type InMemoryState,
@@ -204,6 +206,16 @@ export class StateApply {
 
   upsertInterest(e: HelpWantedInterestExpression): this {
     this.#ops.push((state) => indexHelpWantedInterest(state, e));
+    return this;
+  }
+
+  /**
+   * Mirror a SlugHistory upsert into the in-memory map so the slug-redirect
+   * plugin sees it on the very next request. Expiry filtering happens inside
+   * indexSlugHistory — already-expired records are no-ops here.
+   */
+  upsertSlugHistory(record: SlugHistory): this {
+    this.#ops.push((state) => indexSlugHistory(state, record));
     return this;
   }
 

--- a/apps/api/tests/slug-redirect.test.ts
+++ b/apps/api/tests/slug-redirect.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the slug-history redirect plugin
+ * (apps/api/src/plugins/slug-redirect.ts) — implements
+ * specs/behaviors/slug-handles.md → "Mutability and redirects".
+ *
+ * Covers:
+ *  - Single-hop project + person renames → 301 to the new slug
+ *  - Sub-route preservation (/projects/old/edit → /projects/new/edit)
+ *  - Multi-hop A → B → C in one response
+ *  - Live wins (oldSlug is now a different live entity)
+ *  - Expired entry → no redirect (request continues)
+ *  - Reserved-segment passthrough (/projects/create stays alone)
+ *  - Tag rename (namespace preserved)
+ *  - /api/* paths never hit the hook
+ *  - Query string preserved across redirect
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app.js';
+import { createFullDataRepo, createPrivateStorageDir } from './helpers/test-full-repo.js';
+import { seedRawToml } from './helpers/seed-fixtures.js';
+import { slugHistoryKey } from '../src/store/memory/state.js';
+
+const NOW = '2026-05-27T00:00:00Z';
+const FUTURE = '2027-05-27T00:00:00Z'; // 1 yr — well past the 90-day window
+const PAST = '2025-05-27T00:00:00Z';
+
+let dataRepo: { path: string; cleanup: () => Promise<void> };
+let privateStore: { path: string; cleanup: () => Promise<void> };
+let app: FastifyInstance | undefined;
+
+async function bootApp(): Promise<FastifyInstance> {
+  return buildApp({
+    serverOptions: { logger: false },
+    overrideEnv: {
+      CFP_DATA_REPO_PATH: dataRepo.path,
+      STORAGE_BACKEND: 'filesystem',
+      CFP_PRIVATE_STORAGE_PATH: privateStore.path,
+      CFP_JWT_SIGNING_KEY: 'test-jwt-signing-key-at-least-32-chars!!',
+      NODE_ENV: 'test',
+    },
+  });
+}
+
+async function seedPerson(slug: string, id: string): Promise<void> {
+  await seedRawToml(
+    dataRepo.path,
+    `people/${slug}.toml`,
+    [
+      `id = "${id}"`,
+      `slug = "${slug}"`,
+      `fullName = "Test ${slug}"`,
+      `accountLevel = "user"`,
+      `createdAt = "${NOW}"`,
+      `updatedAt = "${NOW}"`,
+    ].join('\n'),
+    `seed person ${slug}`,
+  );
+}
+
+async function seedProject(slug: string, id: string): Promise<void> {
+  await seedRawToml(
+    dataRepo.path,
+    `projects/${slug}.toml`,
+    [
+      `id = "${id}"`,
+      `slug = "${slug}"`,
+      `title = "Test ${slug}"`,
+      `stage = "testing"`,
+      `featured = false`,
+      `createdAt = "${NOW}"`,
+      `updatedAt = "${NOW}"`,
+    ].join('\n'),
+    `seed project ${slug}`,
+  );
+}
+
+async function seedTag(namespace: string, slug: string, id: string): Promise<void> {
+  await seedRawToml(
+    dataRepo.path,
+    `tags/${namespace}/${slug}.toml`,
+    [
+      `id = "${id}"`,
+      `namespace = "${namespace}"`,
+      `slug = "${slug}"`,
+      `title = "${slug}"`,
+      `createdAt = "${NOW}"`,
+      `updatedAt = "${NOW}"`,
+    ].join('\n'),
+    `seed tag ${namespace}/${slug}`,
+  );
+}
+
+async function seedSlugHistory(
+  entityType: 'project' | 'person' | 'tag',
+  oldSlug: string,
+  newSlug: string,
+  entityId: string,
+  expiresAt: string = FUTURE,
+): Promise<void> {
+  const id = `01951a3c-0000-7000-8000-${Math.random().toString(36).slice(2, 10).padStart(12, '0')}`;
+  await seedRawToml(
+    dataRepo.path,
+    `slug-history/${entityType}/${oldSlug}.toml`,
+    [
+      `id = "${id}"`,
+      `entityType = "${entityType}"`,
+      `oldSlug = "${oldSlug}"`,
+      `newSlug = "${newSlug}"`,
+      `entityId = "${entityId}"`,
+      `changedAt = "${NOW}"`,
+      `expiresAt = "${expiresAt}"`,
+    ].join('\n'),
+    `seed slug-history ${entityType} ${oldSlug}→${newSlug}`,
+  );
+}
+
+beforeEach(async () => {
+  dataRepo = await createFullDataRepo();
+  privateStore = await createPrivateStorageDir();
+});
+
+afterEach(async () => {
+  if (app) {
+    await app.close();
+    app = undefined;
+  }
+  await dataRepo.cleanup();
+  await privateStore.cleanup();
+});
+
+describe('slug-redirect plugin', () => {
+  it('301s a renamed person /members/<old> → /members/<new>', async () => {
+    const id = '01951a3c-0000-7000-8000-000000000101';
+    await seedPerson('chris-a', id);
+    await seedSlugHistory('person', 'chris', 'chris-a', id);
+    app = await bootApp();
+
+    const res = await app.inject({ method: 'GET', url: '/members/chris' });
+    expect(res.statusCode).toBe(301);
+    expect(res.headers.location).toBe('/members/chris-a');
+    expect(res.headers['cache-control']).toContain('max-age=300');
+  });
+
+  it('301s a renamed project /projects/<old> → /projects/<new>', async () => {
+    const id = '01951a3c-0000-7000-8000-000000000201';
+    await seedProject('squadquest-v2', id);
+    await seedSlugHistory('project', 'squadquest', 'squadquest-v2', id);
+    app = await bootApp();
+
+    const res = await app.inject({ method: 'GET', url: '/projects/squadquest' });
+    expect(res.statusCode).toBe(301);
+    expect(res.headers.location).toBe('/projects/squadquest-v2');
+  });
+
+  it('preserves the path suffix when redirecting', async () => {
+    const id = '01951a3c-0000-7000-8000-000000000202';
+    await seedProject('new-name', id);
+    await seedSlugHistory('project', 'old-name', 'new-name', id);
+    app = await bootApp();
+
+    const res = await app.inject({ method: 'GET', url: '/projects/old-name/edit' });
+    expect(res.statusCode).toBe(301);
+    expect(res.headers.location).toBe('/projects/new-name/edit');
+  });
+
+  it('preserves the query string across the redirect', async () => {
+    const id = '01951a3c-0000-7000-8000-000000000203';
+    await seedProject('renamed', id);
+    await seedSlugHistory('project', 'old', 'renamed', id);
+    app = await bootApp();
+
+    const res = await app.inject({ method: 'GET', url: '/projects/old?tab=updates&foo=bar' });
+    expect(res.statusCode).toBe(301);
+    expect(res.headers.location).toBe('/projects/renamed?tab=updates&foo=bar');
+  });
+
+  it('follows a multi-hop chain A → B → C in one response', async () => {
+    const id = '01951a3c-0000-7000-8000-000000000204';
+    await seedProject('c', id);
+    // Two slug-history entries on disk; the in-memory map will store both,
+    // keyed by `project:a` → b and `project:b` → c.
+    await seedSlugHistory('project', 'a', 'b', id);
+    await seedSlugHistory('project', 'b', 'c', id);
+    app = await bootApp();
+
+    const res = await app.inject({ method: 'GET', url: '/projects/a' });
+    expect(res.statusCode).toBe(301);
+    expect(res.headers.location).toBe('/projects/c');
+  });
+
+  it('does not redirect when the oldSlug is a different live entity (live wins)', async () => {
+    // Set up:
+    //   project foo (id A) — once was called bar
+    //   project bar (id B, different project) — now lives at slug "bar"
+    // A request to /projects/bar should serve the *live* project bar, not
+    // redirect to foo. The slug-history record exists but live wins.
+    const idA = '01951a3c-0000-7000-8000-000000000301';
+    const idB = '01951a3c-0000-7000-8000-000000000302';
+    await seedProject('foo', idA);
+    await seedProject('bar', idB);
+    await seedSlugHistory('project', 'bar', 'foo', idA);
+    app = await bootApp();
+
+    const res = await app.inject({ method: 'GET', url: '/projects/bar' });
+    // Not a 301 — the live entity wins. The SPA fallthrough is the next
+    // handler, so we expect either a 200 (SPA HTML) or a 404 (no SPA
+    // bundled in tests). Either way, NOT a redirect.
+    expect(res.statusCode).not.toBe(301);
+  });
+
+  it('skips expired slug-history entries (no redirect, request continues)', async () => {
+    const id = '01951a3c-0000-7000-8000-000000000401';
+    await seedProject('still-here', id);
+    await seedSlugHistory('project', 'ancient', 'still-here', id, PAST);
+    app = await bootApp();
+
+    const res = await app.inject({ method: 'GET', url: '/projects/ancient' });
+    expect(res.statusCode).not.toBe(301);
+  });
+
+  it('lets reserved segments like /projects/create through without redirect', async () => {
+    app = await bootApp();
+    const res = await app.inject({ method: 'GET', url: '/projects/create' });
+    expect(res.statusCode).not.toBe(301);
+  });
+
+  it('301s a renamed tag /tags/<namespace>/<old> → /tags/<namespace>/<new>', async () => {
+    const id = '01951a3c-0000-7000-8000-000000000501';
+    await seedTag('topic', 'transit', id);
+    await seedSlugHistory('tag', 'transportation', 'transit', id);
+    app = await bootApp();
+
+    const res = await app.inject({ method: 'GET', url: '/tags/topic/transportation' });
+    expect(res.statusCode).toBe(301);
+    expect(res.headers.location).toBe('/tags/topic/transit');
+  });
+
+  it('never intercepts /api/* paths', async () => {
+    const id = '01951a3c-0000-7000-8000-000000000601';
+    await seedPerson('alive', id);
+    await seedSlugHistory('person', 'gone', 'alive', id);
+    app = await bootApp();
+
+    // /api/people/<old-slug> is an API path — the slug-history hook must
+    // not touch it. Even if the slug is in slug-history, the route handler
+    // owns the response (a 404 from the people service, in this case).
+    const res = await app.inject({ method: 'GET', url: '/api/people/gone' });
+    expect(res.statusCode).not.toBe(301);
+  });
+
+  it('builds the slugHistoryKey deterministically', () => {
+    expect(slugHistoryKey('project', 'foo')).toBe('project:foo');
+    expect(slugHistoryKey('person', 'chris')).toBe('person:chris');
+    expect(slugHistoryKey('tag', 'transit')).toBe('tag:transit');
+    expect(slugHistoryKey('buzz', 'x')).toBe('buzz:x');
+  });
+});

--- a/plans/slug-history-redirect.md
+++ b/plans/slug-history-redirect.md
@@ -1,9 +1,10 @@
 ---
-status: in-progress
+status: done
 depends: []
 specs:
   - specs/behaviors/slug-handles.md
 issues: [80]
+pr: 92
 ---
 
 # Plan: SlugHistory 90-day redirect handler
@@ -117,13 +118,13 @@ The plugin uses `fastify.addHook('onRequest', ...)` so it fires for every reques
 
 ## Validation
 
-- [ ] `InMemoryState.slugHistory` populated at boot from non-expired records; expired entries skipped.
-- [ ] All three write services call `stateApply.upsertSlugHistory` after the gitsheets upsert.
-- [ ] Fastify plugin registered after `services`, before `static-web`.
-- [ ] All 9 test cases above pass.
-- [ ] Existing 244 API tests still pass.
-- [ ] `npm run type-check && npm run lint` clean.
-- [ ] Spec compliance: GET `/<entity>/<old-slug>` with a non-expired SlugHistory → 301; live wins; multi-hop chain follows; expired → no redirect.
+- [x] `InMemoryState.slugHistory` populated at boot from non-expired records; expired entries skipped via `indexSlugHistory`'s `expiresAt < now` guard.
+- [x] All three write services call `stateApply.upsertSlugHistory` after the gitsheets upsert (`project.write.ts`, `person.write.ts`, `account-claim.ts`'s `MergeApply.replay`).
+- [x] Fastify `slug-redirect` plugin registered after `services`, before `static-web`.
+- [x] 11 test cases pass — single-hop project + person renames, sub-route preservation, query-string preservation, multi-hop A→B→C, live-wins, expired-skip, reserved-segment passthrough, tag rename, `/api/*` never intercepted, key-format determinism.
+- [x] All 255 API tests pass (244 pre-existing + 11 new).
+- [x] `npm run type-check && npm run lint` clean.
+- [x] Spec compliance: GET `/<entity>/<old-slug>` with a non-expired SlugHistory → 301; live wins; multi-hop chain follows; expired → no redirect.
 
 ## Risks / unknowns
 
@@ -135,8 +136,17 @@ The plugin uses `fastify.addHook('onRequest', ...)` so it fires for every reques
 
 ## Notes
 
-*(filled at done time)*
+Shipped over five commits — plan opening + three implementation steps (in-memory state, write-service wiring, Fastify plugin) + tests.
+
+Surprises:
+
+- **Account-claim's MergeApply needed slug-history threading.** Project + person renames live in their own write services where the StateApply is directly accessible, so wiring `upsertSlugHistory` was a one-line addition. Account-claim uses a `MergeApply` wrapper that batches all the post-onboarding rewrites for later replay onto the route-level StateApply — slug-history needed to ride along through that wrapper, which meant adding it to `MergeApplyInput` + `MergeApply.replay`.
+- **Buzz live-index is intentionally fake.** Buzz slugs are keyed by `${projectId}:${buzzSlug}` in the live index (`buzzByProjectAndSlug`); we don't have the projectId cheaply at the URL-pattern level (only the project's slug). For now the buzz pattern always returns `false` from `liveIndex` — which means a slug-history hit always wins for buzz, regardless of whether the buzz slug is live under a different project. No writer currently creates buzz slug-history records, so this is hypothetical.
+- **Tag live-check scans `tagIdByHandle.keys()`.** Tags are uniquely keyed by `(namespace, slug)` but slug-history's key is `tag:<slug>` (no namespace). The live-check walks the handle map looking for any namespace that owns the slug. Tag slug-history has no live writer today either; the conservative live-wins behavior matches the spec.
+- **The 5-min `Cache-Control` is a deliberate undersizing.** 301s are normally aggressively cached by browsers. Because our redirects can expire when the 90-day SlugHistory TTL hits, we keep cache headers short so stale-redirect windows after expiry are bounded to ~5 minutes.
 
 ## Follow-ups
 
-*(filled at done time)*
+- **Periodic sweeper to purge expired SlugHistory records from the sheet.** The read path is already defensive — expired records are filtered at index time — so this is purely about keeping the on-disk sheet from growing forever. *Tracked as*: file a new issue when sheet bloat becomes measurable; today's volume is negligible.
+- **Buzz live-index** — when buzz renames become real, add a `buzzByGlobalSlug` map (or accept the conservative "always redirect on slug-history hit"). *Deferred* until buzz rename writers exist.
+- **CDN/edge cache awareness** — if/when we put the site behind a CDN, 301s would benefit from explicit cache-key handling so the redirect doesn't outlive its TTL at the edge. *Deferred* until cutover plans introduce a CDN.

--- a/plans/slug-history-redirect.md
+++ b/plans/slug-history-redirect.md
@@ -1,0 +1,142 @@
+---
+status: in-progress
+depends: []
+specs:
+  - specs/behaviors/slug-handles.md
+issues: [80]
+---
+
+# Plan: SlugHistory 90-day redirect handler
+
+## Scope
+
+[`specs/behaviors/slug-handles.md`](../specs/behaviors/slug-handles.md) → "Mutability and redirects" specifies that when an entity's slug changes:
+
+> "On any request to a URL using an `oldSlug` that is *not yet* expired, the web layer serves a **301 redirect** to the current canonical URL."
+
+The write side already creates `SlugHistory` records — three call sites (`account-claim.ts:684`, `project.write.ts:303`, `person.write.ts:126`) write to the gitsheets `slug-history` sheet on every rename. The read side is missing: no route checks slug-history to serve the 301. Visiting `/projects/<old-slug>` after a rename 404s (well, falls through to the SPA which then 404s in its data fetch).
+
+This plan fills the gap by:
+
+1. Loading slug-history into the typed in-memory `Store` at boot (the recommended fix path from [#47](https://github.com/CodeForPhilly/codeforphilly-ng/issues/47)).
+2. Keeping that map in lockstep with rename writes via `StateApply.upsertSlugHistory`.
+3. Adding a Fastify `onRequest` hook that pattern-matches the slug-bearing SPA paths, looks up slug-history for misses, and 301s when applicable.
+
+Closes [#80](https://github.com/CodeForPhilly/codeforphilly-ng/issues/80).
+
+## Implements
+
+- [behaviors/slug-handles.md](../specs/behaviors/slug-handles.md) — "Mutability and redirects" + the multi-hop A→B→C rule + the "current slug wins" edge case.
+
+## Approach
+
+### 1. In-memory state — `slugHistory` map
+
+Add to `InMemoryState`:
+
+```ts
+/**
+ * Slug-history index, keyed by `${entityType}:${oldSlug}` → newSlug + expiry.
+ * Populated at boot from non-expired SlugHistory records; updated in lockstep
+ * with rename writes via StateApply.upsertSlugHistory.
+ */
+slugHistory: Map<string, { newSlug: string; expiresAt: string }>;
+```
+
+`indexSlugHistory(state, record)` populates the map. Expired records (where `expiresAt < now`) are dropped at boot — the periodic-sweeper task that purges the sheet is out of scope here (a future follow-up).
+
+The key format mirrors gitsheets' existing `byEntityTypeAndOldSlug` secondary index but the lookup happens entirely in-process.
+
+### 2. Boot loader
+
+`loadInMemoryState` (in `apps/api/src/store/memory/loader.ts`) currently queries 9 sheets. Add `slug-history` as the 10th; call `indexSlugHistory` per record. Compare each record's `expiresAt` against `new Date().toISOString()` and skip the expired ones.
+
+### 3. StateApply.upsertSlugHistory
+
+New op in `apps/api/src/store/state-apply.ts`:
+
+```ts
+upsertSlugHistory(record: SlugHistory): this {
+  this.#ops.push((state) => indexSlugHistory(state, record));
+  return this;
+}
+```
+
+Three write services wire this in immediately after their existing `tx.public['slug-history'].upsert(history)` call:
+
+- `apps/api/src/services/account-claim.ts:684` (post-onboarding merge into legacy person)
+- `apps/api/src/services/project.write.ts:303` (project rename)
+- `apps/api/src/services/person.write.ts:126` (person profile-edit with new slug)
+
+### 4. Fastify `slug-redirect` plugin
+
+`apps/api/src/plugins/slug-redirect.ts` — registered after `services` (which decorates `inMemoryState`) and before `static-web` (which owns the SPA fallthrough notFoundHandler).
+
+Implementation:
+
+- `onRequest` hook (synchronous match; only network I/O is the reply itself).
+- Skip if `request.url.startsWith('/api/')` or the method isn't GET.
+- Parse the URL path against the slug-bearing patterns. Order matters — the deepest match (e.g. project + buzz) wins so a renamed buzz under a renamed project resolves both legs:
+
+  | Pattern | Entity legs |
+  |---|---|
+  | `/projects/:slug/buzz/:buzzSlug` + suffix | project + buzz |
+  | `/projects/:slug` + suffix | project |
+  | `/members/:slug` + suffix | person |
+  | `/tags/:namespace/:slug` + suffix | tag (namespace stays unchanged) |
+
+- For each leg, **live wins**: if the slug is in the live entity index (`projectIdBySlug`, `personIdBySlug`, etc.), don't redirect. This handles the "someone took the freed slug" edge case from the spec.
+- For live-misses, look up in `slugHistory`. If found and not expired, resolve the chain (`A → slugHistory[A] = B → slugHistory[B] = C → C is live, done`) with a `MAX_HOPS = 8` guard against malformed chains.
+- Reconstruct the redirect URL: substitute the resolved slug into the original path and preserve the suffix.
+- Reply with `301 Moved Permanently` + `Location: <newUrl>` + `Cache-Control: max-age=300` (short cache — the redirect itself may expire when the 90-day window does).
+- Reserved-slug carve-outs: `/projects/create`, `/projects/new`, etc. — these are never slugs, so an empty hit in both live + slug-history is fine; the request continues to whatever handles them.
+
+### 5. Plugin registration order
+
+```
+... services (decorates inMemoryState) →
+  slug-redirect (new) →
+  static-web (SPA fallthrough notFoundHandler)
+```
+
+The plugin uses `fastify.addHook('onRequest', ...)` so it fires for every request before routing; static-web's notFoundHandler runs only when no route matches. The slug-redirect hook itself never `reply.send()`s for non-slug paths — it just returns, letting the route or notFoundHandler handle the request.
+
+### 6. Test coverage
+
+`apps/api/tests/slug-redirect.test.ts`:
+
+- Person rename `chris` → `chris-a` → GET `/members/chris` → 301 to `/members/chris-a`
+- Project rename `old-project` → `new-project` → GET `/projects/old-project` → 301
+- Sub-route preserved: GET `/projects/old-project/edit` → 301 to `/projects/new-project/edit`
+- Multi-hop: A→B→C, GET `/projects/A` → 301 to `/projects/C` (single response, chain followed in-process)
+- Live wins: oldSlug X is now a different live entity, GET `/projects/X` → no redirect, SPA serves
+- Expired entry: an `expiresAt` in the past → request continues (no 301)
+- Reserved: GET `/projects/create` → no redirect (slug-history lookup misses cleanly)
+- API route untouched: GET `/api/people/<some-slug>` → never 301s through this hook (rejected before pattern match)
+- Tag rename: GET `/tags/topic/old-tag` → 301 to `/tags/topic/new-tag` (namespace preserved)
+
+## Validation
+
+- [ ] `InMemoryState.slugHistory` populated at boot from non-expired records; expired entries skipped.
+- [ ] All three write services call `stateApply.upsertSlugHistory` after the gitsheets upsert.
+- [ ] Fastify plugin registered after `services`, before `static-web`.
+- [ ] All 9 test cases above pass.
+- [ ] Existing 244 API tests still pass.
+- [ ] `npm run type-check && npm run lint` clean.
+- [ ] Spec compliance: GET `/<entity>/<old-slug>` with a non-expired SlugHistory → 301; live wins; multi-hop chain follows; expired → no redirect.
+
+## Risks / unknowns
+
+- **Hot-reload + slug-history.** Hot-reload re-runs `loadInMemoryState` against a fresh state, then mutates the live state Map in place. Because the slug-history map is part of the same `InMemoryState`, it gets reloaded the same way — no extra wiring needed. Verified by the existing reload pattern.
+- **TTL precision at boot.** We compare `expiresAt < now` once, at load. A record that's not-yet-expired at boot will stay in the map until the pod restarts even if the 90-day window closes mid-life. Acceptable — the spec's 90-day window has a soft edge and pod restarts are frequent enough that staleness windows are bounded. Periodic sweeper is a follow-up.
+- **Buzz / tag rename writers.** The redirect handler supports all four entity types from the spec's enum (project, person, tag, buzz), but the write side only writes slug-history for project + person today. Tag + buzz renames will still work correctly when (if) writers are added — no extra wiring needed at that point.
+- **Cache-Control on the 301.** A long `max-age` on the redirect could outlive the 90-day window in browser caches. We set a short 5-minute cache; longer caches would just stale-redirect for a few minutes after expiry, not catastrophic but worth being conservative.
+- **Path-segment edge cases.** Reserved slugs (`/projects/create`, `/projects/new`) will be checked against `slugHistory` — they'll miss cleanly (no SlugHistory record was ever written for them) and the request continues. No special-casing needed.
+
+## Notes
+
+*(filled at done time)*
+
+## Follow-ups
+
+*(filled at done time)*


### PR DESCRIPTION
## Summary

[\`specs/behaviors/slug-handles.md\`](https://github.com/CodeForPhilly/codeforphilly-ng/blob/main/specs/behaviors/slug-handles.md) → "Mutability and redirects" specifies a 301 redirect for any URL using a non-expired \`oldSlug\`. The write side already creates SlugHistory records on every rename ([\`account-claim.ts\`](https://github.com/CodeForPhilly/codeforphilly-ng/blob/main/apps/api/src/services/account-claim.ts), [\`project.write.ts\`](https://github.com/CodeForPhilly/codeforphilly-ng/blob/main/apps/api/src/services/project.write.ts), [\`person.write.ts\`](https://github.com/CodeForPhilly/codeforphilly-ng/blob/main/apps/api/src/services/person.write.ts)); the read side did nothing with them. This PR fills that gap.

## How it works

1. **In-memory state**: new \`slugHistory: Map<\\\`\${entityType}:\${oldSlug}\\\`, { newSlug, expiresAt }>\` on \`InMemoryState\`. Boot loader populates from the slug-history sheet, filtering past-\`expiresAt\` records (read-path defense; the periodic sweeper that purges the sheet is a follow-up).
2. **StateApply**: new \`upsertSlugHistory(record)\` op. Each of the three write sites that already write to the sheet now also queues the in-memory mutation so the redirect handler sees renames on the very next request.
3. **\`slug-redirect\` Fastify plugin**: \`onRequest\` hook pattern-matches the four slug-bearing SPA paths from \`apps/web/src/App.tsx\` — \`/projects/:slug\`, \`/members/:slug\`, \`/tags/:namespace/:slug\`, \`/projects/:slug/buzz/:buzzSlug\` — and their sub-routes. For live-missing slugs with a non-expired history entry, follows the chain (multi-hop, capped at MAX_HOPS=8) and replies 301 with the rebuilt path. Live entities win over slug-history (handles "someone took the freed slug" from the spec).

Plugin order: \`services\` → \`slug-redirect\` (new) → \`static-web\` (existing SPA fallthrough notFoundHandler). \`/api/*\` paths bypass the hook entirely so route handlers own their own 404 envelopes.

## Test plan

- [x] 11 new test cases in \`apps/api/tests/slug-redirect.test.ts\` (single-hop person + project, sub-route preservation, query-string preservation, multi-hop A→B→C, live wins, expired entry, reserved-segment passthrough, tag rename, /api/* bypass, key-format determinism). All pass.
- [x] All 255 API tests pass (244 pre-existing + 11 new); \`npm run type-check && npm run lint\` clean.
- [ ] **Sandbox smoke (deferred to deploy)** — rename a project via the UI, visit the old URL, expect 301 to the new path with sub-route + query intact.

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)