### PR TITLE
feat(api): welcome email on fresh OAuth signup (closes #43)

### DIFF
--- a/apps/api/src/auth/github-oauth.ts
+++ b/apps/api/src/auth/github-oauth.ts
@@ -169,6 +169,21 @@ export async function completeCallback(
     );
     result.value.stateApply.apply(fastify.inMemoryState, fastify.fts);
 
+    // Fire-and-forget the welcome notification — never block the OAuth
+    // redirect on notifier latency or failures. The notifier already
+    // swallows errors internally and returns `{ delivered: false }`; the
+    // outer .catch handles any unforeseen sync-throw before the SDK is
+    // reached. See plans/welcome-notification.md.
+    void fastify.notifier
+      .notifyWelcomeOnSignup({
+        email: result.value.profile.email,
+        fullName: result.value.person.fullName,
+        slug: result.value.person.slug,
+      })
+      .catch((err) => {
+        fastify.log.error({ err }, 'welcome notification threw (fire-and-forget)');
+      });
+
     const minted = await mintSessionFor(
       result.value.person.id,
       result.value.person.accountLevel,

--- a/apps/api/src/notify/email-notifier.ts
+++ b/apps/api/src/notify/email-notifier.ts
@@ -18,8 +18,9 @@ import type {
   HelpWantedFillNotification,
   HelpWantedInterestNotification,
   Notifier,
+  WelcomeNotification,
 } from './index.js';
-import { renderFilledEmail, renderInterestEmail } from './templates.js';
+import { renderFilledEmail, renderInterestEmail, renderWelcomeEmail } from './templates.js';
 
 export interface EmailNotifierOptions {
   /** Resend client (constructed at boot with the API key from env). */
@@ -95,6 +96,44 @@ export class EmailNotifier implements Notifier {
           roleId: n.roleId,
         },
         'help-wanted interest: email send threw',
+      );
+      return { delivered: false };
+    }
+  }
+
+  async notifyWelcomeOnSignup(n: WelcomeNotification): Promise<{ delivered: boolean }> {
+    if (!n.email) {
+      this.#log.warn(
+        { kind: 'auth.welcome', slug: n.slug },
+        'welcome: no email address; skipped',
+      );
+      return { delivered: false };
+    }
+    const tpl = renderWelcomeEmail(n, this.#siteHost);
+    try {
+      const result = await this.#resend.emails.send({
+        from: this.#from,
+        to: n.email,
+        subject: tpl.subject,
+        text: tpl.text,
+        html: tpl.html,
+      });
+      if (result.error) {
+        this.#log.error(
+          { kind: 'auth.welcome', err: result.error, slug: n.slug },
+          'welcome: Resend reported delivery failure',
+        );
+        return { delivered: false };
+      }
+      this.#log.info(
+        { kind: 'auth.welcome', slug: n.slug, resendId: result.data?.id },
+        'welcome: email queued for delivery',
+      );
+      return { delivered: true };
+    } catch (err) {
+      this.#log.error(
+        { kind: 'auth.welcome', err, slug: n.slug },
+        'welcome: email send threw',
       );
       return { delivered: false };
     }

--- a/apps/api/src/notify/index.ts
+++ b/apps/api/src/notify/index.ts
@@ -30,9 +30,22 @@ export interface HelpWantedFillNotification {
   readonly filledBySlug: string | null;
 }
 
+/**
+ * Welcome notification — fires once per Person on the GitHub OAuth
+ * `create-fresh` outcome (a brand-new signup with no laddr-account-claim
+ * candidates). The email comes from the new PrivateProfile; fullName and
+ * slug from the public Person record.
+ */
+export interface WelcomeNotification {
+  readonly email: string;
+  readonly fullName: string;
+  readonly slug: string;
+}
+
 export interface Notifier {
   notifyHelpWantedInterest(n: HelpWantedInterestNotification): Promise<{ delivered: boolean }>;
   notifyHelpWantedFilled(n: HelpWantedFillNotification): Promise<{ delivered: boolean }>;
+  notifyWelcomeOnSignup(n: WelcomeNotification): Promise<{ delivered: boolean }>;
 }
 
 /**
@@ -53,6 +66,11 @@ export class LoggingNotifier implements Notifier {
 
   async notifyHelpWantedFilled(n: HelpWantedFillNotification): Promise<{ delivered: boolean }> {
     this.#log.info({ kind: 'help-wanted.filled', ...n }, 'help-wanted fill notification');
+    return { delivered: true };
+  }
+
+  async notifyWelcomeOnSignup(n: WelcomeNotification): Promise<{ delivered: boolean }> {
+    this.#log.info({ kind: 'auth.welcome', ...n }, 'welcome notification');
     return { delivered: true };
   }
 }

--- a/apps/api/src/notify/templates.ts
+++ b/apps/api/src/notify/templates.ts
@@ -6,7 +6,11 @@
  * overhead than the strings themselves. URLs are absolute (resolved
  * against the configured siteHost) so links work from email clients.
  */
-import type { HelpWantedFillNotification, HelpWantedInterestNotification } from './index.js';
+import type {
+  HelpWantedFillNotification,
+  HelpWantedInterestNotification,
+  WelcomeNotification,
+} from './index.js';
 
 /** Strip an absolute URL down to scheme + host + path. Useful for log lines. */
 export function buildRoleUrl(siteHost: string, projectSlug: string, roleId: string): string {
@@ -83,6 +87,59 @@ export interface FilledTemplate {
   readonly subject: string;
   readonly text: string;
   readonly html: string;
+}
+
+export interface WelcomeTemplate {
+  readonly subject: string;
+  readonly text: string;
+  readonly html: string;
+}
+
+export function renderWelcomeEmail(
+  n: WelcomeNotification,
+  siteHost: string,
+): WelcomeTemplate {
+  const profileUrl = `https://${siteHost}/members/${encodeURIComponent(n.slug)}`;
+  const projectsUrl = `https://${siteHost}/projects`;
+  const helpWantedUrl = `https://${siteHost}/help-wanted`;
+  const subject = `Welcome to Code for Philly, ${n.fullName}`;
+
+  const text = [
+    `Hey ${n.fullName} — welcome to Code for Philly!`,
+    '',
+    `You're signed in. A few places to start:`,
+    `  - Your profile: ${profileUrl}`,
+    `  - Browse projects: ${projectsUrl}`,
+    `  - Help wanted: ${helpWantedUrl}`,
+    '',
+    `Code for Philly's community lives in Slack — most coordination happens there.`,
+    `Drop into #welcome to introduce yourself.`,
+    '',
+    `— Code for Philly`,
+  ].join('\n');
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<body style="font-family: system-ui, sans-serif; max-width: 32rem; margin: 0 auto; padding: 1rem; color: #111;">
+  <p>Hey <strong>${escapeHtml(n.fullName)}</strong> — welcome to Code for Philly!</p>
+  <p>You're signed in. A few places to start:</p>
+  <ul>
+    <li><a href="${profileUrl}">Your profile</a></li>
+    <li><a href="${projectsUrl}">Browse projects</a></li>
+    <li><a href="${helpWantedUrl}">Help wanted</a></li>
+  </ul>
+  <p>
+    Code for Philly's community lives in Slack — most coordination happens there.
+    Drop into #welcome to introduce yourself.
+  </p>
+  <hr style="border: none; border-top: 1px solid #eee; margin: 2rem 0;">
+  <p style="color: #666; font-size: 0.875rem;">
+    You're receiving this because you just signed in to Code for Philly with GitHub.
+  </p>
+</body>
+</html>`;
+
+  return { subject, text, html };
 }
 
 export function renderFilledEmail(

--- a/apps/api/tests/email-notifier.test.ts
+++ b/apps/api/tests/email-notifier.test.ts
@@ -11,10 +11,15 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 import { EmailNotifier } from '../src/notify/email-notifier.js';
-import { renderFilledEmail, renderInterestEmail } from '../src/notify/templates.js';
+import {
+  renderFilledEmail,
+  renderInterestEmail,
+  renderWelcomeEmail,
+} from '../src/notify/templates.js';
 import type {
   HelpWantedFillNotification,
   HelpWantedInterestNotification,
+  WelcomeNotification,
 } from '../src/notify/index.js';
 
 const noopLogger = {
@@ -49,6 +54,12 @@ const baseFill: HelpWantedFillNotification = {
   projectTitle: 'SquadQuest',
   filledByFullName: 'Jane Doe',
   filledBySlug: 'jane-doe',
+};
+
+const baseWelcome: WelcomeNotification = {
+  email: 'new-user@example.com',
+  fullName: 'New User',
+  slug: 'new-user',
 };
 
 function makeNotifier(emails: { send: ReturnType<typeof vi.fn> }): EmailNotifier {
@@ -152,6 +163,76 @@ describe('EmailNotifier.notifyHelpWantedInterest', () => {
 
     const result = await notifier.notifyHelpWantedInterest(baseInterest);
     expect(result).toEqual({ delivered: false });
+  });
+});
+
+describe('renderWelcomeEmail', () => {
+  it('builds subject + text + html with the user fullName + slug', () => {
+    const tpl = renderWelcomeEmail(baseWelcome, 'codeforphilly.org');
+    expect(tpl.subject).toContain('New User');
+    expect(tpl.text).toContain('Hey New User');
+    expect(tpl.text).toContain('https://codeforphilly.org/members/new-user');
+    expect(tpl.text).toContain('https://codeforphilly.org/projects');
+    expect(tpl.html).toContain('<strong>New User</strong>');
+    expect(tpl.html).toContain('href="https://codeforphilly.org/members/new-user"');
+  });
+
+  it('escapes HTML in fullName', () => {
+    const tpl = renderWelcomeEmail(
+      { ...baseWelcome, fullName: '<script>alert(1)</script>' },
+      'codeforphilly.org',
+    );
+    expect(tpl.html).not.toContain('<script>');
+    expect(tpl.html).toContain('&lt;script&gt;');
+  });
+
+  it('URL-encodes the slug for the profile link', () => {
+    const tpl = renderWelcomeEmail(
+      { ...baseWelcome, slug: 'name with spaces' },
+      'codeforphilly.org',
+    );
+    expect(tpl.html).toContain('href="https://codeforphilly.org/members/name%20with%20spaces"');
+  });
+});
+
+describe('EmailNotifier.notifyWelcomeOnSignup', () => {
+  it('sends via Resend and returns delivered:true', async () => {
+    const send = vi.fn().mockResolvedValue({ data: { id: 'msg-welcome' }, error: null });
+    const notifier = makeNotifier({ send });
+
+    const result = await notifier.notifyWelcomeOnSignup(baseWelcome);
+    expect(result).toEqual({ delivered: true });
+    expect(send).toHaveBeenCalledTimes(1);
+    const arg = send.mock.calls[0]![0]!;
+    expect(arg.to).toBe('new-user@example.com');
+    expect(arg.subject).toContain('Welcome');
+    expect(arg.text).toContain('New User');
+    expect(arg.html).toContain('<strong>New User</strong>');
+  });
+
+  it('returns delivered:false when Resend reports an error', async () => {
+    const send = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'Sender domain unverified' },
+    });
+    const notifier = makeNotifier({ send });
+    const result = await notifier.notifyWelcomeOnSignup(baseWelcome);
+    expect(result).toEqual({ delivered: false });
+  });
+
+  it('returns delivered:false when the SDK throws', async () => {
+    const send = vi.fn().mockRejectedValue(new Error('network blip'));
+    const notifier = makeNotifier({ send });
+    const result = await notifier.notifyWelcomeOnSignup(baseWelcome);
+    expect(result).toEqual({ delivered: false });
+  });
+
+  it('returns delivered:false on empty email (defensive)', async () => {
+    const send = vi.fn();
+    const notifier = makeNotifier({ send });
+    const result = await notifier.notifyWelcomeOnSignup({ ...baseWelcome, email: '' });
+    expect(result).toEqual({ delivered: false });
+    expect(send).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/tests/github-oauth.test.ts
+++ b/apps/api/tests/github-oauth.test.ts
@@ -15,7 +15,7 @@
  * Each test uses a unique remoteAddress so the 10-req/min/IP cap on
  * /api/auth/* doesn't cause one test's setup to fail another test's run.
  */
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { type FastifyInstance } from 'fastify';
 import { writeFile, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -513,6 +513,45 @@ describe('GET /api/auth/github/callback — fresh user outcome', () => {
     const accessValue = session!.split(';')[0]!.replace('cfp_session=', '');
     const claims = await verifyAccess(accessValue, JWT_KEY);
     expect(claims.sub).toBe(person!.id);
+  });
+
+  it('fires the welcome notification with the new person + email', async () => {
+    const ip = nextTestIp();
+    const flow = await startFlow(app, '/', ip);
+
+    // Spy on the boot-installed LoggingNotifier (no Resend in tests).
+    // The notifier call is fire-and-forget — we await the OAuth response
+    // first, then assert the spy. The notifier's spawn is synchronous up
+    // to the await inside it, so it's guaranteed to have been called by
+    // the time the route handler returns.
+    mock.setGitHubUser({
+      id: 88888,
+      login: 'welcome-target',
+      name: 'Welcome Target',
+      avatar_url: 'x',
+    });
+    mock.setGitHubEmails([
+      { email: 'welcome-target@example.com', primary: true, verified: true, visibility: 'public' },
+    ]);
+
+    const spy = vi.spyOn(app.notifier, 'notifyWelcomeOnSignup');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/auth/github/callback?code=abc&state=${encodeURIComponent(flow.state)}`,
+      remoteAddress: ip,
+      cookies: {
+        cfp_oauth_state: flow.stateCookie,
+        cfp_oauth_session: flow.oauthSessionCookie,
+      },
+    });
+    expect(res.statusCode).toBe(302);
+    expect(spy).toHaveBeenCalledWith({
+      email: 'welcome-target@example.com',
+      fullName: 'Welcome Target',
+      slug: 'welcome-target',
+    });
+    spy.mockRestore();
   });
 });
 

--- a/plans/welcome-notification.md
+++ b/plans/welcome-notification.md
@@ -1,9 +1,10 @@
 ---
-status: in-progress
+status: done
 depends: []
 specs:
   - specs/api/auth.md
 issues: [43]
+pr: 99
 ---
 
 # Plan: Welcome notification on fresh OAuth signup
@@ -84,12 +85,12 @@ Wiring-level test: the existing `github-oauth.test.ts` covers the `create-fresh`
 
 ## Validation
 
-- [ ] Three Notifier impls (interface + LoggingNotifier + EmailNotifier) all have the new method.
-- [ ] EmailNotifier sends with the right Resend payload (subject + text + html + to).
-- [ ] Welcome template HTML-escapes `fullName`.
-- [ ] OAuth `create-fresh` path fires the notifier (verified via spy in github-oauth.test.ts).
-- [ ] Existing OAuth tests continue to pass (the notifier call is fire-and-forget; doesn't change response shape).
-- [ ] `npm run type-check && npm run lint && npm test` clean.
+- [x] Three Notifier impls (interface + LoggingNotifier + EmailNotifier) all have `notifyWelcomeOnSignup`.
+- [x] EmailNotifier sends with the right Resend payload (subject + text + html + to).
+- [x] Welcome template HTML-escapes `fullName` (test asserts `<script>` becomes `&lt;script&gt;`).
+- [x] OAuth `create-fresh` path fires the notifier via spy assertion in github-oauth.test.ts — payload matches `{ email, fullName, slug }`.
+- [x] Existing OAuth tests pass (15 pre-existing + 1 new = 16 in that file).
+- [x] 310/310 API tests pass; `npm run type-check && npm run lint` clean.
 
 ## Risks / unknowns
 
@@ -100,8 +101,16 @@ Wiring-level test: the existing `github-oauth.test.ts` covers the `create-fresh`
 
 ## Notes
 
-*(filled at done time)*
+One-shot implementation across two commits (plan + impl/tests).
+
+Surprises:
+
+- **`encodeURIComponent` for the profile-link slug.** Slugs are `[a-z0-9-]` per the spec so they never need encoding today, but the template uses `encodeURIComponent` defensively. Test asserts that a hypothetical slug with spaces produces `name%20with%20spaces` in the href, which gives the template the same robustness as the existing interest/filled renderers.
+- **Spy timing in the OAuth test.** Fire-and-forget worried me — would the spy assertion race the route handler's return? But `void notifier.notifyWelcomeOnSignup(...)` synchronously invokes the function (queuing the promise) before the next statement runs. By the time the route handler resolves and the test awaits the response, the spy has been called at least once. The Resend HTTPS send happens later in the promise chain; we don't await it.
+- **No new env needed.** The notifier already had a `siteHost` from `CFP_SITE_HOST` (added in #82's email-notifier wiring); the welcome template reuses it for the profile/projects/help-wanted links. Zero new config.
 
 ## Follow-ups
 
-*(filled at done time)*
+- **Slack #welcome bump.** Once Slack DM lands (#95), the welcome path could DM the new user with a #welcome channel invite link. Out of scope here; tracked alongside the Slack notifier work.
+- **Email verification reminder.** If the GitHub primary email later fails delivery (Resend bounces it), today the user has no recovery path beyond editing their profile. Tied to the bounce-webhook follow-up from #82.
+- **A/B-able copy.** The body is currently hardcoded. If marketing ever wants to experiment, lift into a small key/value content table in a future plan. *Deferred* — premature for v1.

--- a/plans/welcome-notification.md
+++ b/plans/welcome-notification.md
@@ -1,0 +1,107 @@
+---
+status: in-progress
+depends: []
+specs:
+  - specs/api/auth.md
+issues: [43]
+---
+
+# Plan: Welcome notification on fresh OAuth signup
+
+## Scope
+
+[`apps/api/src/auth/github-oauth.ts`](../apps/api/src/auth/github-oauth.ts) handles the GitHub OAuth callback. The `create-fresh` outcome — a brand-new user with no laddr-account-claim to do — writes a new `Person` + `PrivateProfile`, mints a session, and redirects. No welcome notification today.
+
+This plan adds the third method to the `Notifier` interface (`notifyWelcomeOnSignup`) and fires it from the `create-fresh` path. With the `EmailNotifier` from [#82](https://github.com/CodeForPhilly/codeforphilly-ng/pull/98) already in place, the welcome email lands as soon as `RESEND_API_KEY` is sealed; until then, it logs via `LoggingNotifier`.
+
+Closes [#43](https://github.com/CodeForPhilly/codeforphilly-ng/issues/43).
+
+## Implements
+
+- [api/auth.md](../specs/api/auth.md) — the GitHub OAuth flow's create-fresh user shape gets a notification side-effect.
+
+## Approach
+
+### 1. Extend the `Notifier` interface
+
+In `apps/api/src/notify/index.ts`:
+
+```ts
+export interface WelcomeNotification {
+  readonly email: string;       // PrivateProfile.email
+  readonly fullName: string;    // Person.fullName
+  readonly slug: string;        // Person.slug — used in the profile link
+}
+
+export interface Notifier {
+  notifyHelpWantedInterest(n: HelpWantedInterestNotification): Promise<{ delivered: boolean }>;
+  notifyHelpWantedFilled(n: HelpWantedFillNotification): Promise<{ delivered: boolean }>;
+  notifyWelcomeOnSignup(n: WelcomeNotification): Promise<{ delivered: boolean }>;
+}
+```
+
+Add the no-op `LoggingNotifier.notifyWelcomeOnSignup` and the real `EmailNotifier.notifyWelcomeOnSignup` — same shape as the existing two methods.
+
+### 2. Welcome email template
+
+`apps/api/src/notify/templates.ts` gains `renderWelcomeEmail(n, siteHost)`. Short, warm, single-CTA body:
+
+- Subject: `Welcome to Code for Philly, <fullName>`
+- Text body: 2-3 sentence intro pointing at the projects directory + Slack workspace
+- HTML body: same content + styled link buttons
+- Like the existing templates, HTML-escapes user-supplied fields (`fullName`)
+
+### 3. Wire into the OAuth callback
+
+In `apps/api/src/auth/github-oauth.ts`'s `create-fresh` branch, after `createFresh` resolves:
+
+```ts
+// Fire-and-forget the welcome notification — never block the redirect on
+// notifier latency or failures. The spec for express-interest applies here
+// too: returning 202/302 to the caller regardless of notification outcome.
+void fastify.notifier
+  .notifyWelcomeOnSignup({
+    email: result.value.profile.email,
+    fullName: result.value.person.fullName,
+    slug: result.value.person.slug,
+  })
+  .catch((err) => {
+    fastify.log.error({ err }, 'welcome notification threw (fire-and-forget)');
+  });
+```
+
+Fire-and-forget — Notifier.notifyXxx already returns `{ delivered }` and swallows errors internally, but the outer `.catch` covers any unforeseen sync-throw before the SDK is reached. The OAuth callback's redirect happens on the next line, unblocked.
+
+### 4. Tests
+
+`apps/api/tests/welcome-notification.test.ts`:
+
+- Template renderers — interest-style assertions for subject + body interpolation, HTML escape of `fullName`
+- `EmailNotifier.notifyWelcomeOnSignup` — Resend success, Resend-error, SDK-throw, missing email (defensive — shouldn't happen on the create-fresh path since OAuth requires a primary email, but the interface accepts any string)
+- `LoggingNotifier.notifyWelcomeOnSignup` — logs + returns `delivered: true`
+
+Wiring-level test: the existing `github-oauth.test.ts` covers the `create-fresh` outcome end-to-end. Extend it with one case that asserts `fastify.notifier.notifyWelcomeOnSignup` was called with the right payload (vi.spyOn on the notifier). Don't test that the email *delivered* — that's a notifier-unit concern.
+
+## Validation
+
+- [ ] Three Notifier impls (interface + LoggingNotifier + EmailNotifier) all have the new method.
+- [ ] EmailNotifier sends with the right Resend payload (subject + text + html + to).
+- [ ] Welcome template HTML-escapes `fullName`.
+- [ ] OAuth `create-fresh` path fires the notifier (verified via spy in github-oauth.test.ts).
+- [ ] Existing OAuth tests continue to pass (the notifier call is fire-and-forget; doesn't change response shape).
+- [ ] `npm run type-check && npm run lint && npm test` clean.
+
+## Risks / unknowns
+
+- **Fire-and-forget vs await.** If we await, OAuth callback latency includes one Resend HTTPS round-trip — slow on a cold path, and a Resend outage would stall logins. Fire-and-forget trades email guarantees (a crash before the SDK enqueues drops the email silently) for response latency. Trade is right for v1; if delivery guarantees become important, a small outbox table is the canonical answer.
+- **No retry on Resend failures.** Same trade-off — one shot, log the error, move on. Resend's own retry is good enough for transient blips.
+- **No double-fire on duplicate signups.** OAuth `create-fresh` only fires when a Person was actually created (the `kind === 'create-fresh'` branch), so re-running the callback for an existing user doesn't re-send. Safe.
+- **First-time-Login race with not-yet-sealed Resend key.** If the sandbox flips `RESEND_API_KEY` mid-signup, the in-flight request uses whatever notifier was installed at boot. Negligible — sealing the secret is a deploy event, the pod restart resets everything.
+
+## Notes
+
+*(filled at done time)*
+
+## Follow-ups
+
+*(filled at done time)*


### PR DESCRIPTION
## Summary

Adds the third \`Notifier\` method — \`notifyWelcomeOnSignup\` — and wires it into the GitHub OAuth callback's \`create-fresh\` path. Brand-new users get a welcome email pointing at their profile, the projects directory, help-wanted, and the #welcome Slack channel.

Fire-and-forget — the OAuth redirect doesn't block on Resend latency. The notifier's existing error-handling translates Resend failures to \`delivered: false\` without throwing.

## What's new

- \`notifyWelcomeOnSignup\` on the \`Notifier\` interface + both implementations (\`LoggingNotifier\`, \`EmailNotifier\`).
- \`renderWelcomeEmail\` template — text + HTML, fullName HTML-escaped, slug URL-encoded defensively (slugs are \`[a-z0-9-]\` per spec so encoding is a no-op today, but matches the existing templates' shape).
- One \`void fastify.notifier.notifyWelcomeOnSignup(...).catch(log)\` call in \`github-oauth.ts\`'s create-fresh branch, immediately after \`createFresh\` resolves and before \`mintSessionFor\`.

Inherits the LoggingNotifier fallback from [#82](https://github.com/CodeForPhilly/codeforphilly-ng/pull/98) — when \`RESEND_API_KEY\` is unset (sandbox today), welcomes log to pod stdout; once the secret is sealed, real emails go out automatically. No new env or wiring needed.

## Test plan

- [x] 7 new test cases in \`tests/email-notifier.test.ts\` (template renderer + 4 notifier paths: Resend success, Resend-reported error, SDK throw, missing email).
- [x] 1 new spy assertion in \`tests/github-oauth.test.ts\` — the create-fresh outcome fires the notifier with the right \`{ email, fullName, slug }\` payload.
- [x] 310/310 API tests pass; \`npm run type-check && npm run lint\` clean.
- [ ] **Sandbox smoke (deferred to deploy)** — verify the welcome log line appears on the pod stdout the next time someone hits the OAuth signup path. Switches to real email delivery once \`RESEND_API_KEY\` is sealed.

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)