### PR TITLE
docs(specs): post-cutover-blog audit sync

### DIFF
--- a/specs/api/blog.md
+++ b/specs/api/blog.md
@@ -57,6 +57,7 @@ Standard 404 envelope (per [conventions.md](conventions.md)). Slug-history redir
   "postedAt": "2026-05-15T18:00:00Z",
   "editedAt": "2026-05-16T09:30:00Z",  // null when unedited
   "featuredImageKey": "blog-posts/civic-tech-roundup-2026/cover.jpg",  // or null
+  "featuredImageUrl": "/api/attachments/blog-posts/civic-tech-roundup-2026/cover.jpg",  // or null — derived from featuredImageKey
   "body": "Markdown source",
   "bodyHtml": "<p>...</p>",            // sanitized HTML, server-rendered
   "createdAt": "...",

--- a/specs/api/people.md
+++ b/specs/api/people.md
@@ -12,6 +12,7 @@ See [data-model.md](../data-model.md#person).
 | `GET` | `/api/people/:slug` | public | Fetch a single person's profile. |
 | `PATCH` | `/api/people/:slug` | self \| staff | Update profile. |
 | `POST` | `/api/people/:slug/avatar` | self \| staff | Upload an avatar image (multipart). |
+| `PATCH` | `/api/people/:slug/newsletter` | self \| staff | Update newsletter opt-in state (private-store mutation; no public commit). |
 | `DELETE` | `/api/people/:slug` | administrator | Soft-delete (close account). |
 
 ## GET /api/people

--- a/specs/architecture.md
+++ b/specs/architecture.md
@@ -177,11 +177,21 @@ Runtime configuration (sealed-secrets in our cluster):
 | `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET` | GitHub OAuth app credentials — see [api/auth.md](api/auth.md) |
 | `CFP_JWT_SIGNING_KEY` | HS256 key for session JWTs |
 | `SAML_PRIVATE_KEY` / `SAML_CERTIFICATE` | Slack SAML IdP cert chain — see [api/saml.md](api/saml.md) |
+| `SLACK_TEAM_HOST` | Slack workspace host (default `codeforphilly.slack.com`). Used by the `/chat` redirect ([api/chat](screens/chat.md)) and the SAML SP entity binding. |
+| `RESEND_API_KEY` | Optional. When set, mutates the notifier from the no-op `LoggingNotifier` to the live `EmailNotifier` (Resend SDK). |
+| `CFP_NOTIFICATION_FROM` | Required when `RESEND_API_KEY` is set; the `From:` address on outbound mail. |
+| `CFP_SITE_HOST` | Public site host (e.g., `codeforphilly.org`) — used by notifiers to build canonical URLs in email bodies. |
+| `CFP_DATA_RELOAD_SECRET` | Bearer token gating `POST /api/_internal/reload-data` — the hot-reload webhook. Optional in dev; required in prod. |
 
 On pod start the entrypoint:
 
 1. Runs `git clone` / `git fetch && git reset --hard origin/main` against `CFP_DATA_REMOTE` to populate the data-repo working tree
 2. Boots the API, which loads the gitsheets state and the private-storage `.jsonl` files into memory
+
+Health endpoints:
+
+- `GET /api/health` — liveness; returns 200 with build metadata as long as the process is up.
+- `GET /api/health/ready` — readiness; returns 200 only after the public + private stores have loaded AND the boot-time reconcile has completed. The k8s `readinessProbe` is wired to this so the Service stops routing traffic to a pod that's still loading state.
 
 On every public-side commit the API pushes asynchronously to `CFP_DATA_REMOTE`. On every private-side mutation the API PUTs the relevant `.jsonl` to the bucket synchronously. See the dual-write coordination notes in [behaviors/private-storage.md](behaviors/private-storage.md).
 

--- a/specs/behaviors/app-shell.md
+++ b/specs/behaviors/app-shell.md
@@ -83,7 +83,7 @@ Single search input in the header. Behavior:
 
 - Placeholder: "Search projects, members, tags…"
 - On focus, expands to fit the available space
-- As the user types (debounced 200ms), a dropdown shows up to 8 results across types — matches laddr's site-wide search but in a typeahead form instead of a full results page
+- As the user types (debounced 200ms), a dropdown shows up to 12 results across types (4 per category, see groups below) — matches laddr's site-wide search but in a typeahead form instead of a full results page
 - Result groups:
   - "Projects" — `GET /api/projects?q=...&perPage=4`
   - "Members" — `GET /api/people?q=...&perPage=4`
@@ -124,6 +124,7 @@ Three columns at ≥ md, stacked below.
 - Hackathons → `/pages/hackathons`
 - Members → `/members`
 - Help Wanted → `/help-wanted`
+- Blog → `/blog`
 
 ### Column 2: About
 

--- a/specs/data-model.md
+++ b/specs/data-model.md
@@ -383,7 +383,7 @@ This composite path makes "things with tag X" a single directory traversal in th
 |-------|------|-------|
 | id | uuid | |
 | tagId | uuid | |
-| taggableType | enum | `project` \| `person` \| `help_wanted_role` |
+| taggableType | enum | `project` \| `person` \| `help_wanted_role` \| `blog_post` |
 | taggableId | uuid | |
 | assignedById | uuid nullable | references people.id |
 | createdAt | iso8601 | |

--- a/specs/screens/person-detail.md
+++ b/specs/screens/person-detail.md
@@ -43,7 +43,7 @@ Heading "Recent updates" — last 5 ProjectUpdate items authored by this person,
 
 ### Sidebar (right, ≥ lg)
 
-- "Contact" — Slack DM link if `slackHandle` (deferred field) is set; otherwise hidden in v1
+- "Contact" — Slack DM link if `slackHandle` is set; email shown for self + staff (per the Authorization table below); section hidden when both are absent.
 - "Member since" date
 - For self: "Manage account" link to `/account` (settings spec deferred; covered in account.md when written)
 - For staff: "Audit log" link (deferred)


### PR DESCRIPTION
## Summary

Spec hygiene from a spec-drift audit run after the cutover-blog + screen-gaps work. **No behavior changes** — just bringing the specs in line with what the code already does.

| File | Change |
|---|---|
| \`specs/data-model.md\` | TagAssignment.taggableType section adds \`blog_post\` (the entity overview + Zod schema both already include it; only the section body lagged) |
| \`specs/screens/person-detail.md\` | Drops the "(deferred field)" qualifier on slackHandle; notes Contact also shows email for self+staff |
| \`specs/api/blog.md\` | BlogPost shape documents \`featuredImageUrl\` (derived from \`featuredImageKey\`) |
| \`specs/api/people.md\` | Endpoints table adds \`PATCH /api/people/:slug/newsletter\` |
| \`specs/behaviors/app-shell.md\` | Typeahead cap 8 → 12 (matches the hook's 4-per-category × 3); adds Blog to footer Column 1 |
| \`specs/architecture.md\` | Adds 5 env vars (\`SLACK_TEAM_HOST\`, \`RESEND_API_KEY\`, \`CFP_NOTIFICATION_FROM\`, \`CFP_SITE_HOST\`, \`CFP_DATA_RELOAD_SECRET\`) + a health-endpoints note for the \`/api/health/ready\` readiness probe |

## Audit false-positives flagged

For the record — the auditor reported three "cutover-blocking" findings that turned out to be already-implemented:

- \`/project-buzz/<slug>\` legacy redirect (legacy-redirect.ts:134)
- \`Person.bio\` schema max-length (person.ts:10)
- \`/api/auth/*\` rate-limit cap (rate-limit.ts:79)

Real functional gaps (sign-out-all-devices endpoint+UI, #33 account-level write) stay as separate issues — not part of this PR.

## Test plan

- [x] Spec edits only; no code touched. No tests apply.
- [x] CI's lint/type-check will pass since nothing in \`apps/\` or \`packages/\` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)