### PR TITLE
feat(auth): three-algorithm password verifier + rehash infrastructure

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
     "@fastify/static": "^9.1.3",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.6",
+    "argon2": "^0.44.0",
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.10.0",
     "fastify": "^5.8.5",

--- a/apps/api/src/auth/argon2-params.ts
+++ b/apps/api/src/auth/argon2-params.ts
@@ -1,0 +1,20 @@
+/**
+ * Argon2id parameter source-of-truth.
+ *
+ * Bumping these values is a deliberate spec event per
+ * specs/behaviors/password-hash-rotation.md — every subsequent
+ * successful login rehashes credentials to the new floor, and the
+ * corpus drifts naturally without retroactive backfill.
+ *
+ * Starting values produce ~50 ms hashes on the production pod's CPU
+ * profile (Linode amd64). Within budget for POST /api/auth/login
+ * latency.
+ */
+import argon2 from 'argon2';
+
+export const ARGON2_PARAMS = {
+  type: argon2.argon2id,
+  memoryCost: 19_456, // 19 MiB
+  timeCost: 2, // iterations
+  parallelism: 1,
+} as const;

--- a/apps/api/src/auth/legacy-password.ts
+++ b/apps/api/src/auth/legacy-password.ts
@@ -1,26 +1,139 @@
 /**
- * Legacy laddr password verification.
+ * Legacy password verification + rehash-on-login.
  *
- * Dispatches by hash format prefix so we can support whatever the laddr import
- * lands on. v1 supports bcrypt (`$2a$`, `$2b$`, `$2y$`). Other formats throw
- * UnknownHashFormatError so callers can surface a uniform "credentials invalid"
- * response (rather than leaking algorithm details) while still logging the
- * mismatch internally.
+ * Per specs/behaviors/password-hash-rotation.md. Dispatches by hash
+ * format (SHA-1 unsalted, bcrypt, or argon2id), verifies in constant
+ * time, and reports `needsRehash` so callers can rotate the
+ * credential to argon2id on successful login. The corpus drifts
+ * toward argon2id without forcing a password reset.
+ *
+ * Failure modes — wrong password, missing credential, unknown
+ * format, internal error — collapse to `{ valid: false }` so callers
+ * can return a uniform `invalid_credentials` response without
+ * leaking algorithm or user-existence signal.
  */
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+import argon2 from 'argon2';
 import bcrypt from 'bcryptjs';
 
-export class UnknownHashFormatError extends Error {
-  constructor(prefix: string) {
-    super(`Unknown legacy password hash format: ${prefix}`);
-    this.name = 'UnknownHashFormatError';
+import { ARGON2_PARAMS } from './argon2-params.js';
+
+const BCRYPT_PREFIXES = ['$2a$', '$2b$', '$2y$'];
+const ARGON2ID_PREFIX = '$argon2id$';
+const SHA1_HEX_RE = /^[0-9a-f]{40}$/;
+
+export type VerifyResult =
+  | { valid: true; needsRehash: boolean }
+  | { valid: false };
+
+/**
+ * Verify a plaintext password against a stored hash.
+ *
+ * Returns `{ valid: true, needsRehash }` on a successful match; the
+ * caller is responsible for rotating to argon2id when `needsRehash`
+ * is true.
+ *
+ * Any failure path — wrong password, unrecognized format, internal
+ * error during verify — returns `{ valid: false }` without leaking
+ * the cause. Internal errors are not re-thrown.
+ */
+export async function verifyLegacyPassword(
+  password: string,
+  hash: string,
+): Promise<VerifyResult> {
+  try {
+    if (hash.startsWith(ARGON2ID_PREFIX)) {
+      const ok = await argon2.verify(hash, password);
+      if (!ok) return { valid: false };
+      // Argon2's encoded format embeds the params; if they don't match
+      // the current floor, the credential is correct but stale —
+      // rotate.
+      return { valid: true, needsRehash: argonNeedsRehash(hash) };
+    }
+
+    if (BCRYPT_PREFIXES.some((p) => hash.startsWith(p))) {
+      const ok = await bcrypt.compare(password, hash);
+      if (!ok) return { valid: false };
+      // Spec unifies on argon2id; every bcrypt source rotates on login.
+      // (Laddr is SHA-1, not bcrypt; the bcrypt branch is defensive
+      // fallback for any future bcrypt-imported credentials.)
+      return { valid: true, needsRehash: true };
+    }
+
+    if (SHA1_HEX_RE.test(hash)) {
+      const computedHex = createHash('sha1').update(password).digest('hex');
+      // Length-check before timingSafeEqual — equal lengths are
+      // guaranteed by the regex on `hash` plus sha1's fixed 40-char
+      // output, but defense in depth: timingSafeEqual throws
+      // synchronously on length mismatch, which would itself be a
+      // timing oracle if the throw vs. compare paths differ.
+      if (computedHex.length !== hash.length) return { valid: false };
+      const ok = timingSafeEqual(
+        Buffer.from(computedHex, 'hex'),
+        Buffer.from(hash, 'hex'),
+      );
+      if (!ok) return { valid: false };
+      return { valid: true, needsRehash: true };
+    }
+
+    // Unknown format. No throw — uniform invalid response.
+    return { valid: false };
+  } catch {
+    // Library error, malformed hash that slipped past the regex,
+    // anything else — collapse to invalid. Never leak via different
+    // outcomes.
+    return { valid: false };
   }
 }
 
-const BCRYPT_PREFIXES = ['$2a$', '$2b$', '$2y$'];
+/**
+ * Hash a plaintext password to argon2id with current params. Used
+ * after a successful verify when `needsRehash` is true, and by the
+ * password-reset confirm flow (phase C).
+ */
+export async function rehashPassword(password: string): Promise<string> {
+  return argon2.hash(password, ARGON2_PARAMS);
+}
 
-export async function verifyLaddrPassword(password: string, hash: string): Promise<boolean> {
-  if (BCRYPT_PREFIXES.some((p) => hash.startsWith(p))) {
-    return bcrypt.compare(password, hash);
+/**
+ * Returns true when the supplied argon2id-encoded hash uses
+ * parameters different from the current floor (`ARGON2_PARAMS`).
+ */
+function argonNeedsRehash(hash: string): boolean {
+  try {
+    return argon2.needsRehash(hash, ARGON2_PARAMS);
+  } catch {
+    // If parsing the encoded hash fails, conservatively rotate.
+    return true;
   }
-  throw new UnknownHashFormatError(hash.slice(0, Math.min(4, hash.length)));
+}
+
+/**
+ * Pre-computed argon2id hash of a fixed sentinel plaintext. Computed
+ * lazily on first `dummyVerify` so we don't block module load.
+ */
+let dummyHashPromise: Promise<string> | null = null;
+function ensureDummyHash(): Promise<string> {
+  if (!dummyHashPromise) {
+    dummyHashPromise = rehashPassword('this-string-is-never-a-real-password');
+  }
+  return dummyHashPromise;
+}
+
+/**
+ * Run an argon2 verify against a fixed sentinel hash. Always returns
+ * `{ valid: false }`. Callers invoke this when the user or credential
+ * lookup misses so the overall response timing matches the success
+ * path — per specs/behaviors/password-hash-rotation.md
+ * § anti-enumeration timing.
+ */
+export async function dummyVerify(): Promise<VerifyResult> {
+  try {
+    const dummy = await ensureDummyHash();
+    await argon2.verify(dummy, 'this-string-also-never-a-real-password');
+  } catch {
+    // Outcome doesn't matter — purpose is timing, not correctness.
+  }
+  return { valid: false };
 }

--- a/apps/api/src/routes/account-claim.ts
+++ b/apps/api/src/routes/account-claim.ts
@@ -266,14 +266,10 @@ export async function accountClaimRoutes(fastify: FastifyInstance): Promise<void
 
       const outcome = result.value;
       if (!outcome.ok) {
-        if (outcome.reason === 'unknown_format') {
-          // Internal log — uniform user-facing response per anti-enumeration.
-          request.log.warn(
-            { slug, reason: 'unknown_format' },
-            'legacy password hash format unknown',
-          );
-        }
-        // Uniform 401 for any failure
+        // Uniform 401 for any failure — verifier collapses
+        // wrong-password / unknown-format / internal-error into a
+        // single `wrong_password` reason per
+        // specs/behaviors/password-hash-rotation.md.
         throw new UnauthenticatedError(
           'Invalid credentials',
           'claim_credentials_invalid',

--- a/apps/api/src/services/account-claim.ts
+++ b/apps/api/src/services/account-claim.ts
@@ -38,7 +38,7 @@ import type {
   ClaimPendingClaims,
   GhIdentitySnapshot,
 } from '../auth/jwt.js';
-import { verifyLaddrPassword, UnknownHashFormatError } from '../auth/legacy-password.js';
+import { verifyLegacyPassword } from '../auth/legacy-password.js';
 import { GitHubAccountService } from './github-account.js';
 import type { ResolvedGitHubIdentity } from '../auth/github-client.js';
 
@@ -253,7 +253,7 @@ export class AccountClaimService {
     password: string,
   ): Promise<
     | { ok: true; result: AutoClaimResult }
-    | { ok: false; code: 'invalid'; reason: 'no_slug' | 'already_claimed' | 'no_credential' | 'wrong_password' | 'unknown_format' }
+    | { ok: false; code: 'invalid'; reason: 'no_slug' | 'already_claimed' | 'no_credential' | 'wrong_password' }
   > {
     const personId = this.#state.personIdBySlug.get(slug.toLowerCase());
     if (!personId) {
@@ -272,16 +272,13 @@ export class AccountClaimService {
       return { ok: false, code: 'invalid', reason: 'no_credential' };
     }
 
-    let matched: boolean;
-    try {
-      matched = await verifyLaddrPassword(password, cred.passwordHash);
-    } catch (err) {
-      if (err instanceof UnknownHashFormatError) {
-        return { ok: false, code: 'invalid', reason: 'unknown_format' };
-      }
-      throw err;
-    }
-    if (!matched) {
+    // verifyLegacyPassword collapses wrong-password, unknown-format,
+    // and internal errors into a uniform `{ valid: false }` per
+    // specs/behaviors/password-hash-rotation.md — the byPassword path
+    // surfaces this as `wrong_password` and the route translates to
+    // the uniform `claim_credentials_invalid` user-facing response.
+    const verifyResult = await verifyLegacyPassword(password, cred.passwordHash);
+    if (!verifyResult.valid) {
       return { ok: false, code: 'invalid', reason: 'wrong_password' };
     }
 

--- a/apps/api/tests/account-claim.test.ts
+++ b/apps/api/tests/account-claim.test.ts
@@ -371,6 +371,7 @@ describe('POST /api/account-claim/by-password', () => {
   let app: FastifyInstance;
   const candidateId = '01951a3c-0000-7000-8000-0000ddddddd1';
   const linkedId = '01951a3c-0000-7000-8000-0000ddddddd2';
+  const sha1CandidateId = '01951a3c-0000-7000-8000-0000ddddddd3';
   const correctPassword = 'hunter2-correct';
 
   beforeAll(async () => {
@@ -389,6 +390,15 @@ describe('POST /api/account-claim/by-password', () => {
     });
     await seedPrivateProfile(privateStore.path, linkedId, 'linked@example.com');
     await seedLegacyPassword(privateStore.path, linkedId, hash);
+    // Legacy-laddr candidate with an unsalted SHA-1 hash (the actual
+    // production format per emergence-skeleton User.class.php:33). The
+    // new verifier accepts this path; pre-rewrite the verifier only
+    // knew bcrypt.
+    await seedPerson(dataRepo.path, 'sha1-user', sha1CandidateId);
+    await seedPrivateProfile(privateStore.path, sha1CandidateId, 'sha1-user@example.com');
+    const { createHash } = await import('node:crypto');
+    const sha1Hash = createHash('sha1').update(correctPassword).digest('hex');
+    await seedLegacyPassword(privateStore.path, sha1CandidateId, sha1Hash);
 
     app = await buildTestApp(dataRepo.path, privateStore.path);
   }, 60_000);
@@ -414,6 +424,27 @@ describe('POST /api/account-claim/by-password', () => {
     expect(person?.githubUserId).toBe(3001);
 
     const cred = await app.store.private.getLegacyPassword(candidateId);
+    expect(cred).toBeNull();
+  });
+
+  it('claims on correct password against a SHA-1 hash (legacy laddr format)', async () => {
+    const token = await mintClaim('3010', 'gh-sha1-user', ['gh-sha1-fresh@example.com'], []);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/account-claim/by-password',
+      remoteAddress: nextTestIp(),
+      cookies: { cfp_claim: token },
+      payload: { slug: 'sha1-user', password: correctPassword },
+    });
+    expect(res.statusCode).toBe(200);
+
+    const person = app.inMemoryState.people.get(sha1CandidateId);
+    expect(person?.githubUserId).toBe(3010);
+
+    // Credential deleted on successful claim (per byPassword semantics —
+    // the claim path still removes the credential since the user is now
+    // GitHub-linked. Rehash-on-keep is a phase-B concern.)
+    const cred = await app.store.private.getLegacyPassword(sha1CandidateId);
     expect(cred).toBeNull();
   });
 

--- a/apps/api/tests/legacy-password.test.ts
+++ b/apps/api/tests/legacy-password.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Verifier tests for the three-algorithm dispatcher per
+ * specs/behaviors/password-hash-rotation.md.
+ *
+ * The dummy-verify timing test is intentionally loose (within ~3x of
+ * a real verify on the same machine) — we're checking the order of
+ * magnitude, not micro-benchmarking. Anti-enumeration only needs
+ * "comparable," not "identical."
+ */
+import { createHash } from 'node:crypto';
+
+import argon2 from 'argon2';
+import bcrypt from 'bcryptjs';
+import { describe, expect, it } from 'vitest';
+
+import { ARGON2_PARAMS } from '../src/auth/argon2-params.js';
+import {
+  dummyVerify,
+  rehashPassword,
+  verifyLegacyPassword,
+} from '../src/auth/legacy-password.js';
+
+const CORRECT = 'correct horse battery staple';
+const WRONG = 'tr0ub4dor';
+
+describe('verifyLegacyPassword — argon2id', () => {
+  it('returns valid + no rehash for a hash with current params', async () => {
+    const hash = await argon2.hash(CORRECT, ARGON2_PARAMS);
+    const r = await verifyLegacyPassword(CORRECT, hash);
+    expect(r).toEqual({ valid: true, needsRehash: false });
+  });
+
+  it('returns valid + needsRehash for stale params', async () => {
+    // Lower-cost params than the floor — encodes differently so
+    // argon2.needsRehash returns true.
+    const stale = await argon2.hash(CORRECT, {
+      type: argon2.argon2id,
+      memoryCost: 8192,
+      timeCost: 2,
+      parallelism: 1,
+    });
+    const r = await verifyLegacyPassword(CORRECT, stale);
+    expect(r).toEqual({ valid: true, needsRehash: true });
+  });
+
+  it('returns invalid for wrong password', async () => {
+    const hash = await argon2.hash(CORRECT, ARGON2_PARAMS);
+    const r = await verifyLegacyPassword(WRONG, hash);
+    expect(r).toEqual({ valid: false });
+  });
+});
+
+describe('verifyLegacyPassword — bcrypt', () => {
+  it('returns valid + needsRehash for a bcrypt hash', async () => {
+    const hash = await bcrypt.hash(CORRECT, 4);
+    const r = await verifyLegacyPassword(CORRECT, hash);
+    expect(r).toEqual({ valid: true, needsRehash: true });
+  });
+
+  it('returns invalid for wrong password against a bcrypt hash', async () => {
+    const hash = await bcrypt.hash(CORRECT, 4);
+    const r = await verifyLegacyPassword(WRONG, hash);
+    expect(r).toEqual({ valid: false });
+  });
+});
+
+describe('verifyLegacyPassword — SHA-1 (legacy laddr)', () => {
+  function sha1Hex(input: string): string {
+    return createHash('sha1').update(input).digest('hex');
+  }
+
+  it('returns valid + needsRehash for a correct SHA-1 hash', async () => {
+    const r = await verifyLegacyPassword(CORRECT, sha1Hex(CORRECT));
+    expect(r).toEqual({ valid: true, needsRehash: true });
+  });
+
+  it('returns invalid for wrong password against a SHA-1 hash', async () => {
+    const r = await verifyLegacyPassword(WRONG, sha1Hex(CORRECT));
+    expect(r).toEqual({ valid: false });
+  });
+
+  it('does not throw on a malformed near-SHA-1 input that bypasses the regex check', async () => {
+    // The regex enforces 40 lowercase hex; uppercase hex is rejected
+    // by the regex and falls through to "unknown format" without
+    // throwing.
+    const r = await verifyLegacyPassword(CORRECT, 'ABCDEF0123456789ABCDEF0123456789ABCDEF01');
+    expect(r).toEqual({ valid: false });
+  });
+});
+
+describe('verifyLegacyPassword — unknown format', () => {
+  it('returns invalid for arbitrary strings', async () => {
+    const r = await verifyLegacyPassword(CORRECT, 'not-a-hash');
+    expect(r).toEqual({ valid: false });
+  });
+
+  it('returns invalid for empty hash', async () => {
+    const r = await verifyLegacyPassword(CORRECT, '');
+    expect(r).toEqual({ valid: false });
+  });
+
+  it('returns invalid for an argon2 prefix with corrupt body', async () => {
+    const r = await verifyLegacyPassword(CORRECT, '$argon2id$totally-bogus');
+    expect(r).toEqual({ valid: false });
+  });
+});
+
+describe('rehashPassword', () => {
+  it('produces a parseable argon2id hash that verifies the original plaintext', async () => {
+    const hash = await rehashPassword(CORRECT);
+    expect(hash.startsWith('$argon2id$')).toBe(true);
+    const r = await verifyLegacyPassword(CORRECT, hash);
+    expect(r).toEqual({ valid: true, needsRehash: false });
+  });
+});
+
+describe('dummyVerify (timing floor)', () => {
+  it('always returns invalid', async () => {
+    const r = await dummyVerify();
+    expect(r).toEqual({ valid: false });
+  });
+
+  it('takes time comparable to a real verify (order of magnitude)', async () => {
+    // Warm both paths so the lazy dummy-hash precomputation doesn't
+    // skew the first-call timing.
+    const realHash = await argon2.hash(CORRECT, ARGON2_PARAMS);
+    await verifyLegacyPassword(CORRECT, realHash); // warm argon2
+    await dummyVerify(); // warm dummy hash precomputation
+
+    const t0 = performance.now();
+    await verifyLegacyPassword(CORRECT, realHash);
+    const realMs = performance.now() - t0;
+
+    const t1 = performance.now();
+    await dummyVerify();
+    const dummyMs = performance.now() - t1;
+
+    // Within 3x in either direction. Argon2 timings vary by CI host;
+    // this just guards against the dummy being trivially fast (e.g.
+    // 0.1 ms vs 50 ms would be a measurable enumeration oracle).
+    expect(dummyMs).toBeGreaterThan(realMs / 3);
+    expect(dummyMs).toBeLessThan(realMs * 3);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@fastify/static": "^9.1.3",
         "@fastify/swagger": "^9.7.0",
         "@fastify/swagger-ui": "^5.2.6",
+        "argon2": "^0.44.0",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.10.0",
         "fastify": "^5.8.5",
@@ -1491,6 +1492,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",
@@ -3420,6 +3427,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -6435,6 +6451,22 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "license": "MIT"
     },
+    "node_modules/argon2": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.44.0.tgz",
+      "integrity": "sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "cross-env": "^10.0.0",
+        "node-addon-api": "^8.5.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -7283,6 +7315,23 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -11929,6 +11978,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -11965,6 +12023,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {

--- a/packages/shared/src/schemas/legacy-password-credential.ts
+++ b/packages/shared/src/schemas/legacy-password-credential.ts
@@ -1,9 +1,15 @@
 import { z } from 'zod';
 
+// `lastUsedAt` is populated on every successful login (legacy password
+// path) via the rehash-on-login rule in
+// specs/behaviors/password-hash-rotation.md. Existing imported records
+// have it undefined until first login. Supports the future
+// coverage-metric reporting described in account-migration.md.
 export const LegacyPasswordCredentialSchema = z.object({
   personId: z.string().uuid(),
   passwordHash: z.string().min(1),
   importedAt: z.string().datetime({ offset: true }),
+  lastUsedAt: z.string().datetime({ offset: true }).nullable().optional(),
 });
 
 export type LegacyPasswordCredential = z.infer<typeof LegacyPasswordCredentialSchema>;

--- a/plans/login-migration-impl-phase-a.md
+++ b/plans/login-migration-impl-phase-a.md
@@ -1,10 +1,11 @@
 ---
-status: in-progress
+status: done
 depends: [login-migration-strategy]
 specs:
   - specs/behaviors/password-hash-rotation.md
   - specs/data-model.md
 issues: []
+pr: 118
 ---
 
 # Plan: login-migration impl — phase A (verifier + rehash infrastructure)
@@ -132,13 +133,13 @@ Actually — looking at the current flow, `byPassword` deletes the credential on
 
 ## Validation
 
-- [ ] `npm install --workspace apps/api argon2` lands as its own commit
-- [ ] `verifyLegacyPassword` covers SHA-1 / bcrypt / argon2id paths with the right `needsRehash` flag
-- [ ] SHA-1 compare uses `crypto.timingSafeEqual` after length check
-- [ ] `LegacyPasswordCredential.lastUsedAt` is optional + nullable; existing records parse
-- [ ] `data-model.md` LegacyPasswordCredential section lists `lastUsedAt`
-- [ ] account-claim byPassword still works against bcrypt; gains a SHA-1 case
-- [ ] `npm run type-check && npm run lint && npm test` clean
+- [x] `npm install --workspace apps/api argon2` lands as its own commit
+- [x] `verifyLegacyPassword` covers SHA-1 / bcrypt / argon2id paths with the right `needsRehash` flag — 14 tests
+- [x] SHA-1 compare uses `crypto.timingSafeEqual` after length check
+- [x] `LegacyPasswordCredential.lastUsedAt` is optional + nullable; existing records parse
+- [x] `data-model.md` LegacyPasswordCredential section lists `lastUsedAt` (also updated the surrounding prose to reflect the keep-and-rotate-on-login posture rather than the previous delete-on-claim posture)
+- [x] account-claim `byPassword` still works against bcrypt; gains a SHA-1 case — 17/17 account-claim tests pass
+- [x] `npm run type-check && npm run lint` clean. Full `npm test` sweep validated separately.
 
 ## Risks / unknowns
 
@@ -149,8 +150,44 @@ Actually — looking at the current flow, `byPassword` deletes the credential on
 
 ## Notes
 
-*(filled at done time)*
+Three commits: plan-open, `npm install argon2`, verifier + tests.
+
+Surprises:
+
+- **`UnknownHashFormatError` had a real caller that needed dropping.**
+  `apps/api/src/routes/account-claim.ts:269` distinguished
+  `unknown_format` only for an internal log warning — the user-facing
+  response was uniform either way. With the new verifier collapsing
+  the cases, the internal log branch goes away too. The
+  password-hash-rotation spec's "no algorithm leak even in internal
+  logs" stance is now strict.
+- **`crypto.timingSafeEqual` synchronous throw on length mismatch.**
+  The spec called this out as a timing-oracle if the throw path
+  differs from the compare path. Implementation length-checks the
+  computed-vs-stored hex strings *before* the timing-safe compare —
+  guaranteed identical lengths by the SHA-1 regex + sha1's
+  fixed-40-char output, but defense-in-depth.
+- **`argon2.needsRehash` exists.** Didn't have to roll my own
+  encoded-hash param-comparison. Library does it correctly.
+- **`bcryptjs` already a dep.** Stuck with it (pure JS, no native
+  compile concern) instead of switching to the native `bcrypt`
+  package. The verifier doesn't care which.
+- **Dummy-verify lazy init.** The fixed sentinel hash is computed
+  lazily on first `dummyVerify` call. Avoids blocking module load
+  for ~50ms on every boot. The first request that hits a missing-user
+  path pays the precomputation cost; subsequent requests reuse the
+  cached promise.
 
 ## Follow-ups
 
-*(filled at done time)*
+- **Phase B — `POST /api/auth/login` route.** Wires this verifier
+  into a real login endpoint, with the keep-and-rotate flow that
+  account-claim doesn't trigger (claim deletes the credential on
+  success; login keeps it). *Deferred to plan* —
+  `plans/login-migration-impl-phase-b.md`.
+- **Phase C — password reset.** `POST /api/auth/password-reset/{request,confirm}` + `PasswordToken` private record + email notifier integration. *Deferred to plan* — `plans/login-migration-impl-phase-c.md`.
+- **Phase D — link-github.** `POST /api/auth/link-github` + link-mode OAuth callback variant + account banner + SPA flow. *Deferred to plan* — `plans/login-migration-impl-phase-d.md`.
+- **Param-tuning calibration.** The argon2 params (19 MiB / 2 iter)
+  are starting values per the spec. Once running on the production
+  pod, measure actual per-login latency and adjust. *None* for v1 —
+  not a blocker.

--- a/plans/login-migration-impl-phase-a.md
+++ b/plans/login-migration-impl-phase-a.md
@@ -1,0 +1,156 @@
+---
+status: in-progress
+depends: [login-migration-strategy]
+specs:
+  - specs/behaviors/password-hash-rotation.md
+  - specs/data-model.md
+issues: []
+---
+
+# Plan: login-migration impl — phase A (verifier + rehash infrastructure)
+
+## Scope
+
+First implementation chunk for [login-migration-strategy](./login-migration-strategy.md). This phase is **infrastructure only** — no new user-facing routes yet. It builds the verifier the login route will use:
+
+1. **argon2 dependency** + parameter constants
+2. **Three-algorithm verifier** — SHA-1 (with constant-time compare), bcrypt, argon2id — returning `{ valid, needsRehash }`
+3. **Rehash helper** — produces argon2id encoded hash with current params
+4. **`LegacyPasswordCredential.lastUsedAt` field** — supports the coverage metric
+5. **Existing `account-claim` service** updated to use the new verifier (preserves behavior — same successful auth, same uniform-fail; gains the SHA-1 path so the `wrong_password` outcome for SHA-1 hashes becomes valid)
+
+After this lands, the login route in phase B can call `verifyAndDecideRehash` and rehash via the helper — both pure functions, easy to test.
+
+## Implements
+
+- [behaviors/password-hash-rotation.md](../specs/behaviors/password-hash-rotation.md) — verifier algorithm dispatch, constant-time compare, rehash semantics.
+- [data-model.md → LegacyPasswordCredential](../specs/data-model.md) — `lastUsedAt` field.
+
+## Approach
+
+### 1. Dependency: argon2
+
+```bash
+npm install --workspace apps/api argon2
+```
+
+`argon2` (the native bindings, not `argon2-browser`) — well-maintained, fast, the project's chosen target algorithm. Doesn't need a build step in the Docker image (prebuilt binaries for `linux/amd64`).
+
+### 2. Parameter constants
+
+`apps/api/src/auth/argon2-params.ts` — single source of truth:
+
+```ts
+export const ARGON2_PARAMS = {
+  type: argon2.argon2id,
+  memoryCost: 19456,  // 19 MiB
+  timeCost: 2,
+  parallelism: 1,
+} as const;
+```
+
+Documented per the password-hash-rotation spec. Bumping these is a deliberate spec event.
+
+### 3. Refactor `apps/api/src/auth/legacy-password.ts`
+
+Replace `verifyLaddrPassword(password, hash): Promise<boolean>` with:
+
+```ts
+type VerifyResult =
+  | { valid: true; needsRehash: boolean }
+  | { valid: false };
+
+export async function verifyLegacyPassword(
+  password: string,
+  hash: string,
+): Promise<VerifyResult>;
+
+export async function rehashPassword(password: string): Promise<string>;
+```
+
+`verifyLegacyPassword` dispatches by format:
+
+- `^\$argon2id\$` → `argon2.verify(stored, plaintext)`; `needsRehash` true if encoded params differ from `ARGON2_PARAMS`
+- `^\$2[aby]\$` → `bcrypt.compare(plaintext, stored)`; `needsRehash: true` (we're unifying on argon2id)
+- `^[0-9a-f]{40}$` → SHA-1 path: compute `crypto.createHash('sha1').update(plaintext).digest('hex')`, length-check, `crypto.timingSafeEqual(Buffer, Buffer)`; `needsRehash: true`
+- Anything else → `{ valid: false }` (no throw, no leak)
+
+On any thrown error inside any branch → `{ valid: false }`. Never let internal errors surface as distinct outcomes.
+
+`UnknownHashFormatError` is removed — callers no longer need to distinguish "wrong password" from "unknown format"; both yield `{ valid: false }`.
+
+### 4. Anti-enumeration timing floor
+
+Export a `dummyArgon2Verify()` that runs `argon2.verify` against a fixed argon2id-hashed plaintext. Callers (the future login route, password-reset, etc.) invoke it when the user/credential lookup fails, so wall-clock times across `no user`, `no credential`, `wrong password`, and `valid` paths are comparable.
+
+The dummy hash is computed once at module load (no live secret).
+
+### 5. `LegacyPasswordCredential` schema
+
+`packages/shared/src/schemas/legacy-password-credential.ts`:
+
+```ts
+export const LegacyPasswordCredentialSchema = z.object({
+  personId: z.string().uuid(),
+  passwordHash: z.string().min(1),
+  importedAt: z.string().datetime({ offset: true }),
+  lastUsedAt: z.string().datetime({ offset: true }).nullable().optional(),
+});
+```
+
+Existing records without `lastUsedAt` parse cleanly (optional). New records (rehashed on login) carry `lastUsedAt`.
+
+Update `specs/data-model.md` LegacyPasswordCredential section to list the new field.
+
+### 6. Existing `account-claim` service uses the new verifier
+
+`apps/api/src/services/account-claim.ts:byPassword`:
+
+- Replace `verifyLaddrPassword` import with `verifyLegacyPassword` + `rehashPassword`
+- On `{ valid: true, needsRehash }`: same as today (claim succeeds) — but ALSO rehash + update credential record in the same private-store mutation. The existing `byPassword` path deletes the credential anyway after a successful claim (the user's now GitHub-linked); rehash is a no-op there.
+
+Actually — looking at the current flow, `byPassword` deletes the credential on success, so rehash is moot inside `byPassword`. The new login route (phase B) will be the first caller that *keeps* the credential after success + rehashes. For phase A, the account-claim path stays semantically identical; it just gains the SHA-1 verify path.
+
+### 7. Tests
+
+`apps/api/tests/legacy-password.test.ts` (new):
+
+- Verify argon2id hash with current params → `{ valid: true, needsRehash: false }`
+- Verify argon2id hash with stale params → `{ valid: true, needsRehash: true }`
+- Verify bcrypt hash → `{ valid: true, needsRehash: true }`
+- Verify SHA-1 hash → `{ valid: true, needsRehash: true }`
+- Wrong password against each algorithm → `{ valid: false }`
+- Length-mismatched SHA-1 input doesn't throw, returns `{ valid: false }`
+- Unknown format → `{ valid: false }`, no throw
+- `rehashPassword` produces a parseable argon2id hash
+- `dummyArgon2Verify` returns false but takes comparable time to a real verify (timing approximation — within 2x of a normal argon2 verify)
+
+`apps/api/tests/account-claim.test.ts`:
+
+- Add a SHA-1 hash case that succeeds (proves the new path is wired)
+- Existing bcrypt cases still pass
+
+## Validation
+
+- [ ] `npm install --workspace apps/api argon2` lands as its own commit
+- [ ] `verifyLegacyPassword` covers SHA-1 / bcrypt / argon2id paths with the right `needsRehash` flag
+- [ ] SHA-1 compare uses `crypto.timingSafeEqual` after length check
+- [ ] `LegacyPasswordCredential.lastUsedAt` is optional + nullable; existing records parse
+- [ ] `data-model.md` LegacyPasswordCredential section lists `lastUsedAt`
+- [ ] account-claim byPassword still works against bcrypt; gains a SHA-1 case
+- [ ] `npm run type-check && npm run lint && npm test` clean
+
+## Risks / unknowns
+
+- **`argon2` native build on Apple Silicon dev machines.** The native module needs to compile if no prebuilt is available; should work since the dev `Dockerfile` is x86_64 anyway. If install hangs locally, fall back to `argon2-browser` (pure JS) — slower but no native dep.
+- **`bcrypt.compare` vs `bcryptjs.compare`.** Existing dep is `bcryptjs`. Keep using it — drops the native compile concern.
+- **Length-mismatched SHA-1.** `timingSafeEqual` throws on length mismatch, which is itself a timing oracle. Code must length-check first. Covered by the test.
+- **The rehash-on-bcrypt case is debatable.** Some shops keep bcrypt because changing algorithms is risk. The spec says we unify on argon2id, so this PR rehashes bcrypt → argon2id on successful verify. If usage telemetry later shows bcrypt-source records are zero (they should be — laddr is SHA-1), we can drop the bcrypt branch entirely.
+
+## Notes
+
+*(filled at done time)*
+
+## Follow-ups
+
+*(filled at done time)*

--- a/specs/data-model.md
+++ b/specs/data-model.md
@@ -147,9 +147,9 @@ Sending newsletters is out of scope for v1 (see [deferred.md](deferred.md)). v1 
 
 ## LegacyPasswordCredential _(private)_
 
-Carries a laddr user's old password hash forward through the migration so they can claim their legacy account by typing their old username + password in the [account-claim flow](behaviors/account-migration.md). **The rewrite never creates new records here** — only the laddr import does. **The rewrite never signs in against these credentials at runtime** — only the claim endpoint validates against them, and only as a one-time identity proof during the claim.
+Carries a laddr user's old password hash forward through the migration so they can keep signing in via password indefinitely after cutover — see [behaviors/account-migration.md](behaviors/account-migration.md). The credential stays in place across sessions and is **rehashed in place** on every successful login per [behaviors/password-hash-rotation.md](behaviors/password-hash-rotation.md), so the corpus drifts from laddr's unsalted SHA-1 to argon2id without forcing resets.
 
-When a legacy account is successfully claimed (by any path — email-match, password-match, or staff approval), its `LegacyPasswordCredential` record is deleted. Once all migration claims are completed (or expire), this file drains to zero records and the entity can be removed from the spec entirely.
+The rewrite **creates** new records only via `POST /api/auth/password-reset/confirm` (writing argon2id-hashed plaintext) — never from a sign-up flow.
 
 Password material is sensitive and **must not** appear in the public gitsheets repo — it lives in the private store. See [behaviors/private-storage.md](behaviors/private-storage.md).
 
@@ -158,10 +158,11 @@ Password material is sensitive and **must not** appear in the public gitsheets r
 | Field | Type | Notes |
 |-------|------|-------|
 | personId | uuid | references `Person.id`, 1:1 |
-| passwordHash | string | the laddr password hash, _as-is_. We do not re-hash; we use whatever algorithm laddr used (laddr-era PHP, likely bcrypt or sha512crypt — confirm at migration time). |
+| passwordHash | string | The current password hash. Format is auto-detected by the verifier (SHA-1 hex / bcrypt `$2[aby]$` / argon2id `$argon2id$`). Every successful verify rotates this to argon2id with current params. |
 | importedAt | iso8601 | when the laddr migration wrote this record |
+| lastUsedAt | iso8601 nullable | timestamp of the last successful password sign-in (or password reset). `null` for records that haven't been used since import. Supports the future sunset-coverage report in [behaviors/account-migration.md](behaviors/account-migration.md#coverage-metric-for-future-sunset-planning). |
 
-No `id`, `createdAt`, `updatedAt` — this is import-immutable.
+No `id`, `createdAt`, `updatedAt` — `personId` is the natural key; `importedAt` records creation, `lastUsedAt` records last successful use.
 
 **Secondary in-memory index:**
 


### PR DESCRIPTION
## Summary

Phase A of the login-migration implementation track ([plans/login-migration-strategy.md](https://github.com/CodeForPhilly/codeforphilly-ng/blob/main/plans/login-migration-strategy.md)). **Infrastructure only** — no new user-facing routes yet.

Implements [\`specs/behaviors/password-hash-rotation.md\`](https://github.com/CodeForPhilly/codeforphilly-ng/blob/main/specs/behaviors/password-hash-rotation.md):

- **Three-algorithm verifier** — SHA-1 (constant-time compare), bcrypt, argon2id — returns \`{ valid, needsRehash }\`. Failure modes (wrong password, unknown format, internal error) collapse to a uniform \`{ valid: false }\` so no algorithm or user-existence signal leaks.
- **\`rehashPassword\`** helper produces argon2id at the current param floor.
- **\`dummyVerify\`** runs argon2 verify against a fixed sentinel — used by routes when user/credential lookup misses, keeping wall-clock timing comparable across success and failure paths (anti-enumeration).
- **\`ARGON2_PARAMS\`** single source of truth: 19 MiB / 2 iter / 1 parallelism. Bumping these is a deliberate spec event; subsequent logins rehash to the new floor naturally.
- **\`LegacyPasswordCredential.lastUsedAt\`** — optional nullable; populated on successful login (phase B) to support the coverage metric.

The existing \`account-claim/by-password\` flow migrates to the new verifier and gains a SHA-1 test case. Behavior unchanged otherwise.

## Why this matters

Confirmed against [emergence-skeleton/php-classes/User.class.php:33](https://github.com/JarvusInnovations/emergence-skeleton/blob/develop/php-classes/User.class.php#L33): laddr's \`\$passwordHasher = 'SHA1'\` (unsalted, loose-\`==\` compare). Pre-this-PR the verifier only knew bcrypt — every laddr credential would have hit \`UnknownHashFormatError\` and returned \`wrong_password\`. This PR makes the SHA-1 path work, with constant-time compare and rotation to argon2id.

## Test plan

- [x] 14 new \`legacy-password.test.ts\` cases: argon2id (current + stale params), bcrypt, SHA-1, malformed inputs (no throws), rehash round-trip, dummyVerify timing-floor sanity
- [x] 1 new account-claim case: SHA-1 hash claims correctly through the existing byPassword route
- [x] 357 API + 54 web + 75 shared tests pass
- [x] \`npm run type-check && npm run lint\` clean

## What's next

Phase B wires \`POST /api/auth/login\` (the actual route). Phase C adds password reset. Phase D adds link-GitHub + the account banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)